### PR TITLE
Add the inset text component

### DIFF
--- a/app/components/govuk_component/inset_text.rb
+++ b/app/components/govuk_component/inset_text.rb
@@ -1,0 +1,11 @@
+class GovukComponent::InsetText < ViewComponent::Base
+  attr_accessor :text
+
+  def initialize(text:)
+    @text = text
+  end
+
+  def call
+    tag.div(class: 'govuk-inset-text') { @text }
+  end
+end

--- a/spec/components/panel/govuk_component/inset_text_spec.rb
+++ b/spec/components/panel/govuk_component/inset_text_spec.rb
@@ -1,0 +1,11 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::InsetText, type: :component) do
+  let(:text) { 'Bake him away, toys.' }
+  let(:component) { GovukComponent::InsetText.new(text: text) }
+  subject { Capybara::Node::Simple.new(render_inline(component).to_html) }
+
+  specify 'contains a panel with the correct title and body text' do
+    expect(subject).to have_css('div', class: %w(govuk-inset-text), text: text)
+  end
+end


### PR DESCRIPTION
As this is an incredibly simple component it _probably_ doesn't need an accompanying template, the inline rendering of [inset text](https://design-system.service.gov.uk/components/inset-text/) requires only a single line of Ruby.

Thoughts on this approach? Is it worth taking the longer template approach for consistency or for the simpler ones is this more straightforward?