### PR TITLE
Add breadcrumbs component

### DIFF
--- a/app/components/govuk_component/breadcrumbs.html.erb
+++ b/app/components/govuk_component/breadcrumbs.html.erb
@@ -1,0 +1,15 @@
+<ol class="govuk-breadcrumbs__list">
+  <%- @breadcrumbs.each do |text, link| %>
+
+    <%- if link.present? -%>
+      <li class="govuk-breadcrumbs__list-item">
+        <%= link_to(text, link, class: "govuk-breadcrumbs__link") %>
+      </li>
+    <% else %>
+      <li class="govuk-breadcrumbs__list-item" aria-current="page">
+        <%= text %>
+      </li>
+    <% end %>
+
+  <% end %>
+</ol>

--- a/app/components/govuk_component/breadcrumbs.rb
+++ b/app/components/govuk_component/breadcrumbs.rb
@@ -1,0 +1,7 @@
+class GovukComponent::Breadcrumbs < ViewComponent::Base
+  attr_accessor :breadcrumbs
+
+  def initialize(breadcrumbs:)
+    @breadcrumbs = breadcrumbs
+  end
+end

--- a/spec/components/govuk_component/breadcrumbs_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_spec.rb
@@ -1,0 +1,29 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::Breadcrumbs, type: :component) do
+  let(:breadcrumbs) do
+    {
+      "Home"                 => "/level-one",
+      "Products"             => "/level-two",
+      "Lighting"             => "/level-three",
+      "Anglepoise Desk Lamp" => nil
+    }
+  end
+  let(:component) { GovukComponent::Breadcrumbs.new(breadcrumbs: breadcrumbs) }
+  subject { Capybara::Node::Simple.new(render_inline(component).to_html) }
+
+  specify 'contains correctly-rendered breadcrumbs' do
+    expect(subject).to have_css('ol', class: 'govuk-breadcrumbs__list') do
+      expect(page).to have_css('li', class: 'govuk-breadcrumbs__list-item', count: 4)
+
+      expect(page).to have_css('li > a', class: 'govuk-breadcrumbs__link', count: 3)
+
+      breadcrumbs
+        .reject { |_, link| link.nil? }
+        .each { |text, link| expect(page).to have_link(text, href: link) }
+
+      expect(page).to have_css('li', text: 'Anglepoise Desk Lamp')
+      expect(page).to_not have_link('Anglepoise Desk Lamp')
+    end
+  end
+end

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -14,5 +14,7 @@
 end} %>
 
     <%= render "example", title: 'Start now button', example: %{render GovukComponent::StartNowButton.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education')} %>
+
+    <%= render "example", title: 'Breadcrumbs', example: %{render GovukComponent::Breadcrumbs.new(breadcrumbs: { 'Level one': '/level-one/', 'Level two': '/level-one/level-two/', 'Level three': '/level-one/level-two/level-three' })} %>
   </div>
 </div>


### PR DESCRIPTION
Add a basic breadcrumbs component. It takes a hash `breadcrumbs` in the format `{ link => target }`

```ruby
@breadcrumbs = {
  'Level one'   => '/level-one/',
  'Level two'   => '/level-one/level-two/',
  'Level three' => nil   # don't link to the current page
}
```

```erb
render GovukComponent::Breadcrumbs.new(breadcrumbs: @breadcrumbs)
```