### PR TITLE
Add Back link component

### DIFF
--- a/app/components/govuk_component/back_link.html.erb
+++ b/app/components/govuk_component/back_link.html.erb
@@ -1,3 +1,1 @@
-<a href="<%= @href %>" class="govuk-back-link<% if @classes.present? %> <%= @classes%><% end %>">
-  <%= @text %>
-</a>
+<%= link_to @text, @href, @options  %>

--- a/app/components/govuk_component/back_link.html.erb
+++ b/app/components/govuk_component/back_link.html.erb
@@ -1,0 +1,3 @@
+<a href="<%= @href %>" class="govuk-back-link<% if @classes.present? %> <%= @classes%><% end %>">
+  <%= @text %>
+</a>

--- a/app/components/govuk_component/back_link.rb
+++ b/app/components/govuk_component/back_link.rb
@@ -1,0 +1,9 @@
+class GovukComponent::BackLink < ViewComponent::Base
+  attr_accessor :text, :href
+
+  def initialize(text:, href:, classes: nil)
+    @text = text
+    @href = href
+    @classes = classes
+  end
+end

--- a/app/components/govuk_component/back_link.rb
+++ b/app/components/govuk_component/back_link.rb
@@ -1,9 +1,13 @@
 class GovukComponent::BackLink < ViewComponent::Base
-  attr_accessor :text, :href
+  attr_accessor :text, :href, :options
 
-  def initialize(text:, href:, classes: nil)
+  def initialize(text:, href:, classes: nil, attributes: nil)
     @text = text
     @href = href
-    @classes = classes
+    @classes = "govuk-back-link"
+    @classes << " #{classes}" if classes.present?
+
+    @options = { class: @classes }
+    @options.merge!(attributes) if attributes.present?
   end
 end

--- a/spec/components/govuk_component/back_link_spec.rb
+++ b/spec/components/govuk_component/back_link_spec.rb
@@ -21,7 +21,38 @@ RSpec.describe(GovukComponent::BackLink, type: :component) do
     subject { Capybara::Node::Simple.new(render_inline(component).to_html) }
 
     specify 'contains a link styled as a back link with the correct href' do
-      expect(subject).to have_css('a', text: text, class: %w(govuk-back-link app-custom--class app-custom--class-2))
+      expect(subject).to have_css('a',
+                                  text: text,
+                                  class: %w(govuk-back-link app-custom--class app-custom--class-2))
     end
   end
+
+  context 'accepts custom HTML attributes' do
+    let(:component) {
+      GovukComponent::BackLink.new(text: text, href: href,
+                                   attributes: { data_html5: 'Attributes',
+                                                 id: 'my-back-link'})
+    }
+    subject { Capybara::Node::Simple.new(render_inline(component).to_html) }
+
+    specify 'contains a link styled as a back link with custom html attributes' do
+      expect(subject).to have_css('a', text: text, id: 'my-back-link')
+    end
+  end
+
+  context 'accepts custom css classes and multiple HTML attributes' do
+    let(:component) {
+      GovukComponent::BackLink.new(text: text, href: href, classes: 'app-style',
+                                   attributes: { data_html5: 'Attributes',
+                                                 id: 'my-back-link',
+                                                 data: { tag: 'element'} })
+    }
+    subject { Capybara::Node::Simple.new(render_inline(component).to_html) }
+
+    specify 'contains a link styled as a back link with custom html attributes' do
+      expect(subject).to have_css('a#my-back-link.app-style[data-tag="element"]',
+                                  text: text)
+    end
+  end
+
 end

--- a/spec/components/govuk_component/back_link_spec.rb
+++ b/spec/components/govuk_component/back_link_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::BackLink, type: :component) do
+  let(:text) { 'Department for Education' }
+  let(:href) { 'https://www.gov.uk/government/organisations/department-for-education' }
+
+  context 'default behaviour' do
+    let(:component) { GovukComponent::BackLink.new(text: text, href: href) }
+    subject { Capybara::Node::Simple.new(render_inline(component).to_html) }
+
+    specify 'contains a link styled as a back link with the correct href' do
+      expect(subject).to have_css('a', text: text, class: %w(govuk-back-link))
+    end
+  end
+
+  context 'accepts custom css classes' do
+    let(:component) {
+      GovukComponent::BackLink.new(text: text, href: href,
+                                   classes: 'app-custom--class app-custom--class-2')
+    }
+    subject { Capybara::Node::Simple.new(render_inline(component).to_html) }
+
+    specify 'contains a link styled as a back link with the correct href' do
+      expect(subject).to have_css('a', text: text, class: %w(govuk-back-link app-custom--class app-custom--class-2))
+    end
+  end
+end

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -2,9 +2,17 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">GovukComponents</h1>
 
-    <%= render "example", title: 'Back link - default', example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education')} %>
+    <%= render "example", title: 'Back link - default',
+               example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education')} %>
 
-    <%= render "example", title: 'Back link - with custom css classes', example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education', classes: 'my-class')} %>
+    <%= render "example", title: 'Back link - with custom css classes',
+               example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education', classes: 'my-class')} %>
+
+    <%= render "example", title: 'Back link - with custom HTML attributes',
+               example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education', attributes:{id: "my-link"})} %>
+
+    <%= render "example", title: 'Back link - with custom css classes and HTML attributes',
+               example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education', classes: 'app-class', attributes:{data: {qa: "my-qa-value"}})} %>
 
     <%= render "example", title: 'Inset text', example: %{render GovukComponent::InsetText.new(text: 'Bake him away, toys.')} %>
 

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -2,17 +2,37 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">GovukComponents</h1>
 
-    <%= render "example", title: 'Back link - default',
-               example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education')} %>
+    <%= render "example", title: 'Back link - default', example: \
+%{render GovukComponent::BackLink.new(
+  text: 'Department for Education',
+  href: 'https://www.gov.uk/government/organisations/department-for-education'
+)} %>
 
-    <%= render "example", title: 'Back link - with custom css classes',
-               example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education', classes: 'my-class')} %>
+    <%= render "example", title: 'Back link - with custom css classes', example: \
+%{render GovukComponent::BackLink.new(
+  text: 'Department for Education',
+  href: 'https://www.gov.uk/government/organisations/department-for-education',
+  classes: 'my-class'
+)} %>
 
-    <%= render "example", title: 'Back link - with custom HTML attributes',
-               example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education', attributes:{id: "my-link"})} %>
+    <%= render "example", title: 'Back link - with custom HTML attributes', example: \
+%{render GovukComponent::BackLink.new(
+  text: 'Department for Education',
+  href: 'https://www.gov.uk/government/organisations/department-for-education',
+  attributes:{
+    id: "my-link"
+  }
+)} %>
 
-    <%= render "example", title: 'Back link - with custom css classes and HTML attributes',
-               example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education', classes: 'app-class', attributes:{data: {qa: "my-qa-value"}})} %>
+    <%= render "example", title: 'Back link - with custom css classes and HTML attributes', example: \
+%{render GovukComponent::BackLink.new(
+  text: 'Department for Education',
+  href: 'https://www.gov.uk/government/organisations/department-for-education',
+  classes: 'app-class',
+  attributes:{
+    data: { qa: "my-qa-value"}
+  }
+ )} %>
 
     <%= render "example", title: 'Inset text', example: %{render GovukComponent::InsetText.new(text: 'Bake him away, toys.')} %>
 

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -2,6 +2,10 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">GovukComponents</h1>
 
+    <%= render "example", title: 'Back link - default', example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education')} %>
+
+    <%= render "example", title: 'Back link - with custom css classes', example: %{render GovukComponent::BackLink.new(text: 'Department for Education', href: 'https://www.gov.uk/government/organisations/department-for-education', classes: 'my-class')} %>
+
     <%= render "example", title: 'Inset text', example: %{render GovukComponent::InsetText.new(text: 'Bake him away, toys.')} %>
 
     <%= render "example", title: 'Panel', example: %{render GovukComponent::Panel.new(title: 'Springfield', body: 'A noble spirit embiggens the smallest man')} %>


### PR DESCRIPTION
This PR adds the govuk-frontend back link component:

Guidance and design:
https://design-system.service.gov.uk/components/back-link/

At the moment this component allows developers to pass in
- custom link text
- href
- css classes (optional)
- html attributes (optional)


![screencapture-localhost-3000-2020-05-14-22_56_24](https://user-images.githubusercontent.com/3441519/81990216-a0e53e00-9636-11ea-8655-9cf8dc46d140.png)
