### PR TITLE
Remove csrf_meta_tag from dummy app

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,8 +3,6 @@
   <head>
 <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
     <title>Dummy</title>
-    <meta name="csrf-param" content="authenticity_token">
-<meta name="csrf-token" content="tys28Qfu90k/mBQMeInxwHZsXk7gzWj+sLHN/F+ZCFlI+kGjityWK57VkALdee+1woAVY5usuufal0Thf7C3jg==">
     
 
     <style>/* line 7, node_modules/govuk-frontend/govuk/core/_links.scss */

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -2,7 +2,6 @@
 <html>
   <head>
     <title>Dummy</title>
-    <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
 
     <%= stylesheet_link_tag    'application', media: 'all' %>


### PR DESCRIPTION
We don't need this tag in the dummy app or in the generated examples
page and it's generating unnecessary noise in diffs when we update the
examples.