### PR TITLE
Add mail and button link helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ The gem will include the following components and helpers, [track their progress
 ### Helpers
 
 * `#govuk_link_to` ✔️
-* `#govuk_mail_to`
-* `#govuk_button_to`
+* `#govuk_mail_to` ✔️
+* `#govuk_button_to` ✔️
 * `#govuk_back_to_top_link` ✔️
 * Skip link ✔️
 

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -2,6 +2,14 @@ module GovukLinkHelper
   def govuk_link_to(*args, **kwargs)
     link_to(*args, **{ class: 'govuk-link' }.deep_merge(kwargs))
   end
+
+  def govuk_mail_to(*args, **kwargs)
+    mail_to(*args, **{ class: 'govuk-link' }.deep_merge(kwargs))
+  end
+
+  def govuk_button_to(*args, **kwargs)
+    button_to(*args, **{ class: 'govuk-button' }.deep_merge(kwargs))
+  end
 end
 
 ActiveSupport.on_load(:action_view) { include GovukLinkHelper }

--- a/docs/index.html
+++ b/docs/index.html
@@ -10683,6 +10683,28 @@ end</code></pre>
   </section>
 </article>
 
+    <article class="example govuk-!-margin-top-9" id="email-links">
+  <h2 class="govuk-heading-s">Email links</h2>
+  <section>
+    <a class="govuk-link" href="mailto:Home">test@test.org</a>
+  </section>
+  <section>
+    <pre><code class="language-ruby">govuk_mail_to('Home', 'test@test.org')</code></pre>
+  </section>
+</article>
+
+    <article class="example govuk-!-margin-top-9" id="button-links">
+  <h2 class="govuk-heading-s">Button links</h2>
+  <section>
+    <form class="button_to" method="post" action="/">
+<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="2XVL+ClTE8x4pt9YsIBl9TXoTbXHKBei3xiabOqo05yxsN869T7d4gZonWhB2xfmhjGdtJp+BndSUrbINcScdw==">
+</form>
+  </section>
+  <section>
+    <pre><code class="language-ruby">govuk_button_to('Home', '/')</code></pre>
+  </section>
+</article>
+
 
     <article class="example govuk-!-margin-top-9" id="back-to-top-link">
   <h2 class="govuk-heading-s">Back to top link</h2>

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -53,6 +53,8 @@ end} %>
     <%= render "example", title: 'Header without service name', example: %{render GovukComponent::Header.new(logo: 'Custom')} %>
 
     <%= render "example", title: 'Links', example: %{govuk_link_to('Home', '/')} %>
+    <%= render "example", title: 'Email links', example: %{govuk_mail_to('Home', 'test@test.org')} %>
+    <%= render "example", title: 'Button links', example: %{govuk_button_to('Home', '/')} %>
 
     <%= render "example", title: 'Back to top link', example: %{govuk_back_to_top_link} %>
 

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
   include ActionView::Helpers::UrlHelper
 
   let(:text) { 'Menu' }
-  let(:url) { '/stuff/menu/' }
   subject { Capybara::Node::Simple.new(component) }
 
   describe '#govuk_link_to' do
+    let(:url) { '/stuff/menu/' }
     let(:component) { govuk_link_to(text, url) }
     it { is_expected.to(have_link(text, href: url, class: 'govuk-link')) }
 
@@ -30,6 +30,70 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify 'has the custom classes' do
         expect(subject).to(have_link(text, href: url, class: custom_class))
+      end
+    end
+  end
+
+  describe '#govuk_mail_to' do
+    let(:email_address) { %(test@something.org) }
+    let(:target) { %(mailto:) + email_address }
+    let(:component) { govuk_mail_to(email_address, text) }
+    it { is_expected.to(have_link(text, href: target, class: 'govuk-link')) }
+
+    context 'when additional classes are passed in' do
+      let(:custom_class) { 'yellow' }
+      let(:component) { govuk_mail_to(email_address, text, class: custom_class) }
+
+      specify 'has the custom classes' do
+        expect(subject).to(have_link(text, href: target, class: [custom_class]))
+      end
+
+      specify 'does not have the default class' do
+        expect(subject).not_to(have_link(text, href: target, class: 'govuk-link'))
+      end
+    end
+
+    context 'when additional classes are passed in as arrays' do
+      let(:custom_class) { %w(yellow) }
+      let(:component) { govuk_mail_to(email_address, text, class: custom_class) }
+
+      specify 'has the custom classes' do
+        expect(subject).to(have_link(text, href: target, class: custom_class))
+      end
+    end
+  end
+
+  describe '#govuk_button_to' do
+    let(:url) { '/stuff/menu/' }
+    let(:component) { govuk_button_to(text, url) }
+    it { is_expected.to(have_button(text, class: 'govuk-button')) }
+
+    specify 'has form with correct url containing submit input with supplied text' do
+      expect(subject).to have_css(%(form)) do |form|
+        expect(form['action']).to eql(url)
+        expect(form).to have_button(text, class: 'govuk-button')
+      end
+    end
+
+    context 'when additional classes are passed in' do
+      let(:custom_class) { 'yellow' }
+      let(:component) { govuk_button_to(text, url, class: custom_class) }
+
+      specify 'has the custom classes' do
+        expect(subject).to(have_button(text, class: [custom_class]))
+      end
+
+      specify 'does not have the default class' do
+        expect(subject).not_to(have_button(text, class: 'govuk-button'))
+      end
+    end
+
+    context 'when additional classes are passed in as arrays' do
+      let(:custom_class) { %w(yellow) }
+      let(:component) { govuk_button_to(text, url, class: custom_class) }
+
+      specify 'has the custom classes' do
+        expect(subject).to(have_button(text, class: custom_class))
       end
     end
   end


### PR DESCRIPTION
These are very similar to the `govuk_link_to` helper. The tests appear repetitive but that can be easily solved using shared examples once #33 is merged.

![Screenshot from 2020-06-11 15-43-44](https://user-images.githubusercontent.com/128088/84400953-9a78c080-abfa-11ea-9842-9505150f1075.png)
