### PR TITLE
Allow header navigation to be set using slots

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ PATH
   remote: .
   specs:
     govuk-components (0.1.0)
-      rails (~> 6.0.2, >= 6.0.2.2)
+      rails (~> 6.0.3, >= 6.0.3)
       slim-rails (~> 3.2)
       view_component (~> 2.18.1)
 
@@ -68,7 +68,7 @@ GEM
       public_suffix (>= 2.0.2, < 5.0)
     builder (3.2.4)
     byebug (11.1.3)
-    capybara (3.32.1)
+    capybara (3.33.0)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -107,7 +107,7 @@ GEM
     pry-byebug (3.9.0)
       byebug (~> 11.0)
       pry (~> 0.13.0)
-    public_suffix (4.0.4)
+    public_suffix (4.0.5)
     rack (2.2.3)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
@@ -138,7 +138,7 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.20.3, < 2.0)
     rake (13.0.1)
-    regexp_parser (1.7.0)
+    regexp_parser (1.7.1)
     rspec-core (3.9.2)
       rspec-support (~> 3.9.3)
     rspec-expectations (3.9.2)

--- a/app/components/govuk_component/header.html.erb
+++ b/app/components/govuk_component/header.html.erb
@@ -19,7 +19,20 @@
           <%= @service_name %>
         </a>
       <% end %>
-      <%= nav %>
+
+      <% if items.any? %>
+        <nav>
+          <ul class="govuk-header__navigation " aria-label="Top Level Navigation">
+            <% items.each do |item| %>
+              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if item.active? %>">
+                <a class="govuk-header__link" href="<%= item.href %>">
+                  <%= item.title %>
+                </a>
+              </li>
+            <% end %>
+          </ul>
+        </nav>
+      <% end %>
     </div>
   </div>
 </header>

--- a/app/components/govuk_component/header.rb
+++ b/app/components/govuk_component/header.rb
@@ -1,12 +1,28 @@
 class GovukComponent::Header < ViewComponent::Base
+  include ViewComponent::Slotable
+
   attr_accessor :logo, :logo_href, :service_name, :service_name_href
 
-  with_content_areas :nav
+  with_slot :item, collection: true, class_name: 'Item'
 
   def initialize(logo: 'GOV.UK', logo_href: '/', service_name: nil, service_name_href: '/')
     @logo              = logo
     @logo_href         = logo_href
     @service_name      = service_name
     @service_name_href = service_name_href
+  end
+
+  class Item < ViewComponent::Slot
+    attr_accessor :title, :href, :active
+
+    def initialize(title:, href:, active: false)
+      self.title  = title
+      self.href   = href
+      self.active = active
+    end
+
+    def active?
+      active
+    end
   end
 end

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency "rails", "~> 6.0.2", ">= 6.0.2.2"
+  spec.add_dependency "rails", "~> 6.0.3", ">= 6.0.3"
   spec.add_dependency "slim-rails", "~> 3.2"
   spec.add_dependency "view_component", "~> 2.18.1"
 

--- a/spec/components/govuk_component/header_spec.rb
+++ b/spec/components/govuk_component/header_spec.rb
@@ -14,18 +14,15 @@ RSpec.describe(GovukComponent::Header, type: :component) do
     }
   end
 
-  subject do
-    Capybara::Node::Simple.new(render_inline(component).to_html)
-  end
+  let(:component) { GovukComponent::Header.new(**default_args) }
+  subject! { render_inline(component) }
 
   context 'when only the logo and service are specified' do
-    let(:component) { GovukComponent::Header.new(**default_args) }
-
     specify 'outputs a header with correct logo and service name' do
-      expect(subject).to have_css('.govuk-header') do
-        expect(page).to have_css('span', class: 'govuk-header__logotype-text', text: logo)
-        expect(page).to have_css('.govuk-header__content') do
-          expect(page).to have_link(service_name, href: service_name_href, class: %w(govuk-header__link govuk-header__link--service-name))
+      expect(page).to have_css('.govuk-header') do |header|
+        expect(header).to have_css('span', class: 'govuk-header__logotype-text', text: logo)
+        expect(header).to have_css('.govuk-header__content') do |content|
+          expect(content).to have_link(service_name, href: service_name_href, class: %w(govuk-header__link govuk-header__link--service-name))
         end
       end
     end
@@ -34,12 +31,62 @@ RSpec.describe(GovukComponent::Header, type: :component) do
       let(:component) { GovukComponent::Header.new(**default_args.except(:service_name)) }
 
       specify 'no service name related markup should be present' do
-        expect(subject).not_to have_css('.govuk-header__link--service-name')
+        expect(page).not_to have_css('.govuk-header__link--service-name')
       end
     end
   end
 
-  xcontext 'when a navigation menu is supplied' do
-    specify 'the navigation block should be present in the output'
+  describe 'navigation menus' do
+    context 'when no navigation items are supplied' do
+      specify 'the navigation block should not be present in the output' do
+        expect(page).not_to have_css('nav')
+      end
+    end
+
+    context 'when navigation items are supplied' do
+      let(:items) do
+        [
+          { title: 'Item 1', href: '/item-1' },
+          { title: 'Item 2', href: '/item-2', active: true },
+          { title: 'Item 3', href: '/item-3' }
+        ]
+      end
+
+      subject! do
+        render_inline(GovukComponent::Header.new(**default_args)) do |component|
+          items.each { |item| component.slot(:item, **item) }
+        end
+      end
+
+      specify 'the navigation block should be present in the output' do
+        expect(page).to have_css('nav')
+      end
+
+      specify 'the correct number of navigation items should be present' do
+        page.find('nav') do |nav|
+          expect(nav).to have_css('.govuk-header__link', count: items.size)
+        end
+      end
+
+      specify 'the navigation menu markup should be correct' do
+        structure = %w(nav ul.govuk-header__navigation li.govuk-header__navigation-item a.govuk-header__link)
+
+        expect(page).to have_css(structure.join(' > '), count: items.size)
+      end
+
+      specify 'the item titles and hrefs should be correct' do
+        page.find('nav') do |nav|
+          items.each { |link| expect(nav).to have_link(link[:title], href: link[:href]) }
+        end
+      end
+
+      specify 'the link with active: true should have the active class' do
+        active_link = items.detect { |item| item[:active] }
+
+        page.find('nav') do |nav|
+          expect(nav).to have_css('li', text: active_link[:title], class: 'govuk-header__navigation-item--active', count: 1)
+        end
+      end
+    end
   end
 end

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -51,6 +51,15 @@ end} %>
 
     <%= render "example", title: 'Header', example: %{render GovukComponent::Header.new(logo: 'GOV.UK', service_name: 'Amazing service', service_name_href: '/amazing-service/home')} %>
     <%= render "example", title: 'Header without service name', example: %{render GovukComponent::Header.new(logo: 'Custom')} %>
+    <%= render "example", title: 'Header with navigation', example: <<~HEADER
+      render GovukComponent::Header.new(logo: 'Some service') do |component|
+        component.slot(:item, title: 'Page A', href: '/#page-a')
+        component.slot(:item, title: 'Page B', href: '/#page-b')
+        component.slot(:item, title: 'Page C', href: '/#page-c', active: true)
+      end
+    HEADER
+    %>
+
 
     <%= render "example", title: 'Links', example: %{govuk_link_to('Home', '/')} %>
     <%= render "example", title: 'Email links', example: %{govuk_mail_to('Home', 'test@test.org')} %>


### PR DESCRIPTION
Add navigation item support to the header.

For the moment I'm just calling the links 'items', 'navigation_items' seems a bit long-winded. Suggestions welcome

![Screenshot from 2020-08-19 11-49-29](https://user-images.githubusercontent.com/128088/90625952-37b32f00-e212-11ea-896f-1e8deebc90ba.png)
