### PR TITLE
Accordion component

### DIFF
--- a/app/components/govuk_component/accordion.html.erb
+++ b/app/components/govuk_component/accordion.html.erb
@@ -1,0 +1,21 @@
+<%= content_tag('div', id: @id, class: classes, data: { module: 'govuk-accordion' }) do %>
+  <% sections.each do |section| %>
+    <div id="<%= section.id(suffix: 'section') %>" class="govuk-accordion__section">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span class="govuk-accordion__section-button" id="<%= section.id %>">
+            <%= section.title %>
+          </span>
+        </h2>
+        <% if section.summary.present? %>
+          <div class="govuk-accordion__section-summary govuk-body" id="<%= section.id(suffix: 'summary') %>">
+            <%= section.summary %>
+          </div>
+        <% end %>
+      </div>
+      <div id="<%= section.id(suffix: 'content') %>" class="govuk-accordion__section-content" aria-labelledby="<%= section.id %>">
+        <%= section.content %>
+      </div>
+    </div>
+  <% end %>
+<% end %>

--- a/app/components/govuk_component/accordion.rb
+++ b/app/components/govuk_component/accordion.rb
@@ -1,0 +1,32 @@
+class GovukComponent::Accordion < GovukComponent::Base
+  include ViewComponent::Slotable
+
+  with_slot :section, collection: true, class_name: 'Section'
+
+  attr_accessor :id
+
+  def initialize(id: nil, classes: [])
+    super(classes: classes)
+
+    @id = id
+  end
+
+private
+
+  def default_classes
+    %w(govuk-accordion)
+  end
+
+  class Section < ViewComponent::Slot
+    attr_accessor :title, :summary
+
+    def initialize(title:, summary: nil)
+      self.title   = title
+      self.summary = summary
+    end
+
+    def id(suffix: nil)
+      [title.parameterize, suffix].compact.join('-')
+    end
+  end
+end

--- a/spec/components/govuk_component/accordion_spec.rb
+++ b/spec/components/govuk_component/accordion_spec.rb
@@ -1,0 +1,76 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::Accordion, type: :component) do
+  let(:sections) do
+    {
+      'section 1' => 'first section content',
+      'section 2' => 'second section content',
+      'section 3' => 'third section content'
+    }
+  end
+
+  subject! do
+    render_inline(GovukComponent::Accordion.new) do |component|
+      sections.each do |title, content|
+        component.slot(:section, title: title) { content }
+      end
+    end
+  end
+
+  specify 'an accordion with the correct number of sections should be rendered' do
+    expect(page).to have_css('div.govuk-accordion') do |accordion|
+      expect(accordion).to have_css('.govuk-accordion__section', count: sections.size)
+    end
+  end
+
+  context 'when an ID is set for the accordion' do
+    let(:id) { 'fancy-accordion' }
+    subject! do
+      render_inline(GovukComponent::Accordion.new(id: id))
+    end
+
+    specify 'the id should be set correctly' do
+      expect(page).to have_css("##{id}")
+    end
+  end
+
+  specify 'the sections should have the correct title and content' do
+    sections.each do |title, content|
+      expect(page).to have_css("##{title.parameterize}-section.govuk-accordion__section") do |section|
+        expect(section).to have_css('.govuk-accordion__section-button', text: title)
+        expect(section).to have_css('.govuk-accordion__section-content', text: content)
+      end
+    end
+  end
+
+  specify 'the section ids should match content aria-labelledby' do
+    sections.each do |title, _|
+      id = "#{title.parameterize}"
+
+      expect(page).to have_css('#' + id)
+      expect(page).to have_css(%(div[aria-labelledby='#{id}']))
+    end
+  end
+
+  describe 'summaries' do
+    context 'when no summary is present' do
+      specify 'no summary should be present' do
+        expect(page).not_to have_css('.govuk-accordion__section-summary')
+      end
+    end
+
+    context 'when a summary is present' do
+      let(:title) { 'summary' }
+      let(:summary_content) { 'summary content' }
+      subject! do
+        render_inline(GovukComponent::Accordion.new) do |component|
+          component.slot(:section, title: title, summary: summary_content) { 'abc' }
+        end
+      end
+
+      specify 'the summary should be present and have the correct id and classes' do
+        expect(page).to have_css("##{title}-summary.govuk-accordion__section-summary", text: summary_content)
+      end
+    end
+  end
+end

--- a/spec/components/govuk_component/tabs_spec.rb
+++ b/spec/components/govuk_component/tabs_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe(GovukComponent::Tabs, type: :component) do
     }
   end
 
-  before do
+  subject! do
     render_inline(GovukComponent::Tabs.new(title: title)) do |component|
       tabs.each do |title, content|
         component.slot(:tab, title: title) { content }

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -99,5 +99,25 @@ end} %>
       end
     TABS
     %>
+
+    <%= render "example", title: "Accordion", example: <<~ACCORDION
+      render GovukComponent::Accordion.new(id: 'abc123') do |component|
+        component.slot(:section, title: 'Home electronics', summary: 'Entertainment, communication and recreation') do
+          tag.p("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", class: 'govuk-body')
+        end
+
+        component.slot(:section, title: 'Appliances', summary: 'Laundry, cookers and vacuum cleaners') do
+          tag.p("Ut et elementum tortor. Donec a tellus sed sem euismod congue", class: 'govuk-body')
+        end
+
+        component.slot(:section, title: 'Toys') do
+          safe_join([
+            tag.p("In et nunc vitae tortor sollicitudin ultrices. Vivamus a purus justo.", class: 'govuk-body'),
+            tag.p("Duis a turpis non nunc pulvinar venenatis quis congue mauris. Nullam vel consequat diam, vel venenatis nulla.", class: 'govuk-body')
+          ])
+        end
+      end
+    ACCORDION
+    %>
   </div>
 </div>


### PR DESCRIPTION
Add the accordion component

```ruby
render GovukComponent::Accordion.new(id: 'abc123') do |component|
  component.slot(:section, title: 'Home electronics', summary: 'Entertainment, communication and recreation') do
    tag.p("Lorem ipsum dolor sit amet, consectetur adipiscing elit.", class: 'govuk-body')
  end

  component.slot(:section, title: 'Appliances', summary: 'Laundry, cookers and vacuum cleaners') do
    tag.p("Ut et elementum tortor. Donec a tellus sed sem euismod congue", class: 'govuk-body')
  end

  component.slot(:section, title: 'Toys') do
    safe_join([
      tag.p("In et nunc vitae tortor sollicitudin ultrices. Vivamus a purus justo.", class: 'govuk-body'),
      tag.p("Duis a turpis non nunc pulvinar venenatis quis congue mauris. Nullam vel consequat diam, vel venenatis nulla.", class: 'govuk-body')
    ])
  end
end
```

![Screenshot from 2020-08-19 17-14-49](https://user-images.githubusercontent.com/128088/90661810-85925c00-e23f-11ea-9694-7e2e1c5dfaaf.png)
