### PR TITLE
Custom HTML attributes

### DIFF
--- a/app/components/govuk_component/accordion.html.erb
+++ b/app/components/govuk_component/accordion.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(id: @id, class: classes, data: { module: 'govuk-accordion' }) do %>
+<%= tag.div(id: @id, class: classes, data: { module: 'govuk-accordion' }, **html_attributes) do %>
   <% sections.each do |section| %>
     <%= tag.div(id: section.id(suffix: 'section'), class: "govuk-accordion__section") do %>
       <div class="govuk-accordion__section-header">

--- a/app/components/govuk_component/accordion.html.erb
+++ b/app/components/govuk_component/accordion.html.erb
@@ -1,6 +1,6 @@
 <%= tag.div(id: @id, class: classes, data: { module: 'govuk-accordion' }, **html_attributes) do %>
   <% sections.each do |section| %>
-    <%= tag.div(id: section.id(suffix: 'section'), class: "govuk-accordion__section") do %>
+    <%= tag.div(id: section.id(suffix: 'section'), class: section.classes, **section.html_attributes) do %>
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
           <%= tag.span(section.title, id: section.id, class: "govuk-accordion__section-button") %>

--- a/app/components/govuk_component/accordion.rb
+++ b/app/components/govuk_component/accordion.rb
@@ -5,8 +5,8 @@ class GovukComponent::Accordion < GovukComponent::Base
 
   attr_accessor :id
 
-  def initialize(id: nil, classes: [])
-    super(classes: classes)
+  def initialize(id: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @id = id
   end

--- a/app/components/govuk_component/accordion.rb
+++ b/app/components/govuk_component/accordion.rb
@@ -17,16 +17,24 @@ private
     %w(govuk-accordion)
   end
 
-  class Section < ViewComponent::Slot
+  class Section < GovukComponent::Slot
     attr_accessor :title, :summary
 
-    def initialize(title:, summary: nil)
+    def initialize(title:, summary: nil, classes: [], html_attributes: {})
+      super(classes: classes, html_attributes: html_attributes)
+
       self.title   = title
       self.summary = summary
     end
 
     def id(suffix: nil)
       [title.parameterize, suffix].compact.join('-')
+    end
+
+  private
+
+    def default_classes
+      %w(govuk-accordion__section)
     end
   end
 end

--- a/app/components/govuk_component/back_link.html.erb
+++ b/app/components/govuk_component/back_link.html.erb
@@ -1,1 +1,1 @@
-<%= link_to @text, @href, **options %>
+<%= link_to @text, @href, class: classes, **html_attributes %>

--- a/app/components/govuk_component/back_link.rb
+++ b/app/components/govuk_component/back_link.rb
@@ -1,21 +1,16 @@
 class GovukComponent::BackLink < GovukComponent::Base
   attr_accessor :text, :href, :options
 
-  def initialize(text:, href:, classes: nil, attributes: {})
-    super(classes: classes)
+  def initialize(text:, href:, classes: nil, html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
-    @text       = text
-    @href       = href
-    @attributes = attributes
+    @text = text
+    @href = href
   end
 
 private
 
   def default_classes
     %w(govuk-back-link)
-  end
-
-  def options
-    { class: classes }.merge(@attributes)
   end
 end

--- a/app/components/govuk_component/base.rb
+++ b/app/components/govuk_component/base.rb
@@ -1,6 +1,9 @@
 class GovukComponent::Base < ViewComponent::Base
-  def initialize(classes: [])
-    @classes = parse_classes(classes)
+  attr_reader :html_attributes
+
+  def initialize(classes: [], html_attributes: {})
+    @classes         = parse_classes(classes)
+    @html_attributes = html_attributes
   end
 
   def classes

--- a/app/components/govuk_component/breadcrumbs.html.erb
+++ b/app/components/govuk_component/breadcrumbs.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: classes) do %>
+<%= tag.div(class: classes, **html_attributes) do %>
   <ol class="govuk-breadcrumbs__list">
     <%- @breadcrumbs.each do |text, link| %>
 

--- a/app/components/govuk_component/breadcrumbs.rb
+++ b/app/components/govuk_component/breadcrumbs.rb
@@ -1,8 +1,8 @@
 class GovukComponent::Breadcrumbs < GovukComponent::Base
   attr_accessor :breadcrumbs
 
-  def initialize(breadcrumbs:, classes: [])
-    super(classes: classes)
+  def initialize(breadcrumbs:, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @breadcrumbs = breadcrumbs
   end

--- a/app/components/govuk_component/details.html.erb
+++ b/app/components/govuk_component/details.html.erb
@@ -1,4 +1,4 @@
-<%= tag.details(class: classes, data: { module: 'govuk-details' }) do %>
+<%= tag.details(class: classes, data: { module: 'govuk-details' }, **html_attributes) do %>
   <summary class="govuk-details__summary">
     <span class="govuk-details__summary-text">
       <%= @summary %>

--- a/app/components/govuk_component/details.rb
+++ b/app/components/govuk_component/details.rb
@@ -1,8 +1,8 @@
 class GovukComponent::Details < GovukComponent::Base
   attr_accessor :summary, :description
 
-  def initialize(summary:, description: nil, classes: [])
-    super(classes: classes)
+  def initialize(summary:, description: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @summary     = summary
     @description = description

--- a/app/components/govuk_component/footer.html.erb
+++ b/app/components/govuk_component/footer.html.erb
@@ -1,4 +1,4 @@
-<footer class="govuk-footer " role="contentinfo">
+<%= tag.footer(class: classes, role: 'contentinfo', **html_attributes) do %>
   <div class="govuk-width-container ">
     <% if content.present? %>
       <%= content %>
@@ -19,7 +19,7 @@
           <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
         </svg>
         <span class="govuk-footer__licence-description">
-          <%= @licence %>
+          <%= licence %>
         </span>
       </div>
       <div class="govuk-footer__meta-item">
@@ -27,4 +27,4 @@
       </div>
     </div>
   </div>
-</footer>
+<% end %>

--- a/app/components/govuk_component/footer.rb
+++ b/app/components/govuk_component/footer.rb
@@ -1,16 +1,20 @@
 class GovukComponent::Footer < GovukComponent::Base
   attr_accessor :meta, :licence, :copyright
 
-  def initialize(meta_links: nil, meta_heading: default_meta_heading, licence: nil, copyright_text: default_copright_text, copyright_url: default_copyright_url, classes: [])
-    super(classes: classes)
+  def initialize(meta_links: nil, meta_heading: default_meta_heading, licence: nil, copyright_text: default_copright_text, copyright_url: default_copyright_url, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @meta_links   = build_meta_links(meta_links)
     @meta_heading = raw(tag.h2(meta_heading, class: 'govuk-visually-hidden'))
-    @licence      = licence || default_licence
+    @licence      = raw(licence).presence || default_licence
     @copyright    = build_copyright(copyright_text, copyright_url)
   end
 
 private
+
+  def default_classes
+    %w(govuk-footer)
+  end
 
   def build_meta_links(links)
     return [] if links.blank?

--- a/app/components/govuk_component/header.html.erb
+++ b/app/components/govuk_component/header.html.erb
@@ -1,4 +1,4 @@
-<%= tag.header(class: classes, role: 'banner', data: { module: 'govuk-header' }) do %>
+<%= tag.header(class: classes, role: 'banner', data: { module: 'govuk-header' }, **html_attributes) do %>
   <div class="govuk-header__container govuk-width-container">
     <div class="govuk-header__logo">
       <a href=<%= @logo_href %> class="govuk-header__link govuk-header__link--homepage">

--- a/app/components/govuk_component/header.html.erb
+++ b/app/components/govuk_component/header.html.erb
@@ -24,11 +24,11 @@
         <nav>
           <ul class="govuk-header__navigation " aria-label="Top Level Navigation">
             <% items.each do |item| %>
-              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if item.active? %>">
+              <%= tag.li(class: item.classes.append(item.active_class), **item.html_attributes) do %>
                 <a class="govuk-header__link" href="<%= item.href %>">
                   <%= item.title %>
                 </a>
-              </li>
+              <% end %>
             <% end %>
           </ul>
         </nav>

--- a/app/components/govuk_component/header.rb
+++ b/app/components/govuk_component/header.rb
@@ -5,8 +5,8 @@ class GovukComponent::Header < GovukComponent::Base
 
   with_slot :item, collection: true, class_name: 'Item'
 
-  def initialize(logo: 'GOV.UK', logo_href: '/', service_name: nil, service_name_href: '/', classes: [])
-    super(classes: classes)
+  def initialize(logo: 'GOV.UK', logo_href: '/', service_name: nil, service_name_href: '/', classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @logo              = logo
     @logo_href         = logo_href

--- a/app/components/govuk_component/header.rb
+++ b/app/components/govuk_component/header.rb
@@ -20,10 +20,12 @@ private
     %w(govuk-header)
   end
 
-  class Item < ViewComponent::Slot
+  class Item < GovukComponent::Slot
     attr_accessor :title, :href, :active
 
-    def initialize(title:, href:, active: false)
+    def initialize(title:, href:, active: false, classes: [], html_attributes: {})
+      super(classes: classes, html_attributes: html_attributes)
+
       self.title  = title
       self.href   = href
       self.active = active
@@ -31,6 +33,16 @@ private
 
     def active?
       active
+    end
+
+    def active_class
+      %w(govuk-header__navigation-item--active) if active?
+    end
+
+  private
+
+    def default_classes
+      %w(govuk-header__navigation-item)
     end
   end
 end

--- a/app/components/govuk_component/inset_text.rb
+++ b/app/components/govuk_component/inset_text.rb
@@ -1,14 +1,14 @@
 class GovukComponent::InsetText < GovukComponent::Base
   attr_accessor :text
 
-  def initialize(text:, classes: [])
-    super(classes: classes)
+  def initialize(text:, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @text = text
   end
 
   def call
-    tag.div(class: classes) { @text }
+    tag.div(class: classes, **html_attributes) { @text }
   end
 
 private

--- a/app/components/govuk_component/panel.html.erb
+++ b/app/components/govuk_component/panel.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: classes) do %>
+<%= tag.div(class: classes, **html_attributes) do %>
   <h1 class="govuk-panel__title">
     <%= @title %>
   </h1>

--- a/app/components/govuk_component/panel.rb
+++ b/app/components/govuk_component/panel.rb
@@ -1,8 +1,8 @@
 class GovukComponent::Panel < GovukComponent::Base
   attr_accessor :title, :body
 
-  def initialize(title:, body:, classes: [])
-    super(classes: classes)
+  def initialize(title:, body:, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @title = title
     @body  = body

--- a/app/components/govuk_component/phase_banner.html.erb
+++ b/app/components/govuk_component/phase_banner.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: classes) do %>
+<%= tag.div(class: classes, **html_attributes) do %>
   <p class="govuk-phase-banner__content">
     <strong class="govuk-tag govuk-phase-banner__content__tag">
       <%= @phase %>

--- a/app/components/govuk_component/phase_banner.rb
+++ b/app/components/govuk_component/phase_banner.rb
@@ -1,8 +1,8 @@
 class GovukComponent::PhaseBanner < GovukComponent::Base
   attr_accessor :phase, :text
 
-  def initialize(phase:, text: nil, classes: [])
-    super(classes: classes)
+  def initialize(phase:, text: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @phase = phase
     @text  = text

--- a/app/components/govuk_component/slot.rb
+++ b/app/components/govuk_component/slot.rb
@@ -1,4 +1,4 @@
-class GovukComponent::Base < ViewComponent::Base
+class GovukComponent::Slot < ViewComponent::Slot
   include GovukComponent::Traits::CustomClasses
   include GovukComponent::Traits::CustomHtmlAttributes
 

--- a/app/components/govuk_component/start_now_button.html.erb
+++ b/app/components/govuk_component/start_now_button.html.erb
@@ -1,4 +1,4 @@
-<%= link_to(@href, role: 'button', draggable: 'false', class: classes, data: { module: 'govuk-button' }) do %>
+<%= link_to(@href, role: 'button', draggable: 'false', class: classes, data: { module: 'govuk-button' }, **html_attributes) do %>
     <%= @text %>
     <svg class="govuk-button__start-icon" xmlns="http://www.w3.org/2000/svg" width="17.5" height="19" viewBox="0 0 33 40" aria-hidden="true" focusable="false">
       <path fill="currentColor" d="M0 0h13l20 20-20 20H0l20-20z" />

--- a/app/components/govuk_component/start_now_button.rb
+++ b/app/components/govuk_component/start_now_button.rb
@@ -1,8 +1,8 @@
 class GovukComponent::StartNowButton < GovukComponent::Base
   attr_accessor :text, :href
 
-  def initialize(text:, href:, classes: [])
-    super(classes: classes)
+  def initialize(text:, href:, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @text = text
     @href = href

--- a/app/components/govuk_component/summary_list.html.erb
+++ b/app/components/govuk_component/summary_list.html.erb
@@ -1,6 +1,6 @@
 <%= tag.dl(class: classes, **html_attributes) do %>
   <% rows.each do |row| %>
-    <div class="govuk-summary-list__row">
+    <%= tag.div(class: row.classes, **row.html_attributes) do %>
       <dt class="govuk-summary-list__key">
         <%= row.key %>
       </dt>
@@ -14,6 +14,6 @@
           <%= row.action %>
         </dd>
       <% end %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/govuk_component/summary_list.html.erb
+++ b/app/components/govuk_component/summary_list.html.erb
@@ -1,4 +1,4 @@
-<%= tag.dl(class: classes) do %>
+<%= tag.dl(class: classes, **html_attributes) do %>
   <% rows.each do |row| %>
     <div class="govuk-summary-list__row">
       <dt class="govuk-summary-list__key">

--- a/app/components/govuk_component/summary_list.rb
+++ b/app/components/govuk_component/summary_list.rb
@@ -13,13 +13,21 @@ private
     %w(govuk-summary-list)
   end
 
-  class Row < ViewComponent::Slot
+  class Row < GovukComponent::Slot
     attr_accessor :key, :value, :action
 
-    def initialize(key:, value:, action: nil)
+    def initialize(key:, value:, action: nil, classes: [], html_attributes: {})
+      super(classes: classes, html_attributes: html_attributes)
+
       self.key    = key
       self.value  = value
       self.action = action
+    end
+
+  private
+
+    def default_classes
+      %w(govuk-summary-list__row)
     end
   end
 end

--- a/app/components/govuk_component/tabs.html.erb
+++ b/app/components/govuk_component/tabs.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: classes, data: { module: 'govuk-tabs' }) do %>
+<%= tag.div(class: classes, data: { module: 'govuk-tabs' }, **html_attributes) do %>
   <h2 class="govuk-tabs__title">
     <%= title %>
   </h2>

--- a/app/components/govuk_component/tabs.html.erb
+++ b/app/components/govuk_component/tabs.html.erb
@@ -12,8 +12,8 @@
     <% end %>
   </ul>
   <% tabs.each.with_index do |tab, i| %>
-    <div class="govuk-tabs__panel <%= 'govuk-tabs__panel--hidden' unless i.zero? %>" id="<%= tab.id %>">
+    <%= tag.div(class: tab.classes.append(tab.hidden_class(i)), id: tab.id, **tab.html_attributes) do %>
       <%= tab.content %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/govuk_component/tabs.rb
+++ b/app/components/govuk_component/tabs.rb
@@ -5,8 +5,8 @@ class GovukComponent::Tabs < GovukComponent::Base
 
   with_slot :tab, collection: true, class_name: 'Tab'
 
-  def initialize(title:, classes: [])
-    super(classes: classes)
+  def initialize(title:, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     self.title = title
   end

--- a/app/components/govuk_component/tabs.rb
+++ b/app/components/govuk_component/tabs.rb
@@ -17,15 +17,25 @@ private
     %w(govuk-tabs)
   end
 
-  class Tab < ViewComponent::Slot
+  class Tab < GovukComponent::Slot
     attr_accessor :title
 
-    def initialize(title:)
+    def initialize(title:, classes: [], html_attributes: {})
+      super(classes: classes, html_attributes: html_attributes)
+
       self.title = title
     end
 
     def id(prefix: nil)
       [prefix, title.parameterize].join
+    end
+
+    def default_classes
+      %w(govuk-tabs__panel)
+    end
+
+    def hidden_class(i = nil)
+      %(govuk-tabs__panel--hidden) unless i&.zero?
     end
   end
 end

--- a/app/components/govuk_component/traits/custom_classes.rb
+++ b/app/components/govuk_component/traits/custom_classes.rb
@@ -1,0 +1,29 @@
+module GovukComponent
+  module Traits
+    module CustomClasses
+
+      def classes
+        default_classes.concat(Array.wrap(@classes))
+      end
+
+      def default_classes
+        Rails.logger.warn(%(#default_classes hasn't been defined in #{self.class}))
+
+        []
+      end
+
+    private
+
+      def parse_classes(classes)
+        return [] unless classes.present?
+
+        case classes
+        when Array
+          classes
+        when String
+          classes.split
+        end
+      end
+    end
+  end
+end

--- a/app/components/govuk_component/traits/custom_html_attributes.rb
+++ b/app/components/govuk_component/traits/custom_html_attributes.rb
@@ -1,0 +1,7 @@
+module GovukComponent
+  module Traits
+    module CustomHtmlAttributes
+      attr_reader :html_attributes
+    end
+  end
+end

--- a/app/components/govuk_component/warning.html.erb
+++ b/app/components/govuk_component/warning.html.erb
@@ -1,4 +1,4 @@
-<%= content_tag('div', class: classes) do %>
+<%= content_tag('div', class: classes, **html_attributes) do %>
   <span class="govuk-warning-text__icon" aria-hidden="true">!</span>
   <strong class="govuk-warning-text__text">
     <span class="govuk-warning-text__assistive"><%= @icon_fallback_text %></span>

--- a/app/components/govuk_component/warning.rb
+++ b/app/components/govuk_component/warning.rb
@@ -1,6 +1,6 @@
 class GovukComponent::Warning < GovukComponent::Base
-  def initialize(text:, icon_fallback_text: 'Warning', classes: [])
-    super(classes: classes)
+  def initialize(text:, icon_fallback_text: 'Warning', classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
 
     @text = text
     @icon_fallback_text = icon_fallback_text

--- a/spec/components/govuk_component/accordion_spec.rb
+++ b/spec/components/govuk_component/accordion_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(GovukComponent::Accordion, type: :component) do
+  let(:id) { 'fancy-accordion' }
   let(:sections) do
     {
       'section 1' => 'first section content',
@@ -8,6 +9,8 @@ RSpec.describe(GovukComponent::Accordion, type: :component) do
       'section 3' => 'third section content'
     }
   end
+
+  let(:kwargs) { { id: id } }
 
   subject! do
     render_inline(GovukComponent::Accordion.new) do |component|
@@ -24,9 +27,8 @@ RSpec.describe(GovukComponent::Accordion, type: :component) do
   end
 
   context 'when an ID is set for the accordion' do
-    let(:id) { 'fancy-accordion' }
     subject! do
-      render_inline(GovukComponent::Accordion.new(id: id))
+      render_inline(GovukComponent::Accordion.new(**kwargs))
     end
 
     specify 'the id should be set correctly' do
@@ -73,4 +75,7 @@ RSpec.describe(GovukComponent::Accordion, type: :component) do
       end
     end
   end
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/accordion_spec.rb
+++ b/spec/components/govuk_component/accordion_spec.rb
@@ -78,4 +78,13 @@ RSpec.describe(GovukComponent::Accordion, type: :component) do
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
+
+  context 'slot arguments' do
+    let(:slot) { :section }
+    let(:content) { ->{ 'some swanky accordion content' } }
+    let(:slot_kwargs) { { title: 'A title', summary: 'A summary' } }
+
+    it_behaves_like 'a component with a slot that accepts custom classes'
+    it_behaves_like 'a component with a slot that accepts custom html attributes'
+  end
 end

--- a/spec/components/govuk_component/back_link_spec.rb
+++ b/spec/components/govuk_component/back_link_spec.rb
@@ -3,45 +3,16 @@ require 'spec_helper'
 RSpec.describe(GovukComponent::BackLink, type: :component) do
   let(:text) { 'Department for Education' }
   let(:href) { 'https://www.gov.uk/government/organisations/department-for-education' }
-  let(:node) { Capybara::Node::Simple.new(render_inline(component).to_html) }
+  let(:kwargs) { { text: text, href: href } }
 
   context 'default behaviour' do
-    let(:component) { GovukComponent::BackLink.new(text: text, href: href) }
+    before { render_inline(GovukComponent::BackLink.new(**kwargs)) }
 
     specify 'contains a link styled as a back link with the correct href' do
-      expect(node).to have_css('a', text: text, class: %w(govuk-back-link))
+      expect(page).to have_css('a', text: text, class: %w(govuk-back-link))
     end
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { GovukComponent::BackLink }
-    let(:kwargs) { { text: text, href: href } }
-  end
-
-  context 'accepts custom HTML attributes' do
-    let(:component) {
-      GovukComponent::BackLink.new(text: text, href: href,
-                                   attributes: { data_html5: 'Attributes',
-                                                 id: 'my-back-link'})
-    }
-
-    specify 'contains a link styled as a back link with custom html attributes' do
-      expect(node).to have_css('a', text: text, id: 'my-back-link')
-    end
-  end
-
-  context 'accepts custom css classes and multiple HTML attributes' do
-    let(:component) {
-      GovukComponent::BackLink.new(text: text, href: href, classes: 'app-style',
-                                   attributes: { data_html5: 'Attributes',
-                                                 id: 'my-back-link',
-                                                 data: { tag: 'element'} })
-    }
-
-    specify 'contains a link styled as a back link with custom html attributes' do
-      expect(node).to have_css('a#my-back-link.app-style[data-tag="element"]',
-                                  text: text)
-    end
-  end
-
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/breadcrumbs_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe(GovukComponent::Breadcrumbs, type: :component) do
     end
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { described_class }
-  end
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/details_spec.rb
+++ b/spec/components/govuk_component/details_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe(GovukComponent::Details, type: :component) do
     end
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { described_class }
-  end
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/footer_spec.rb
+++ b/spec/components/govuk_component/footer_spec.rb
@@ -1,84 +1,85 @@
 require 'spec_helper'
 
 RSpec.describe(GovukComponent::Footer, type: :component) do
-  subject do
-    Capybara::Node::Simple.new(render_inline(component).to_html)
+  include_context 'helpers'
+
+  let(:custom_copyright) { "All rights reserved" }
+  let(:custom_copyright_url) { "https://en.wikipedia.org/wiki/All_rights_reserved" }
+  let(:custom_licence_url) { "https://mit-license.org/" }
+  let(:custom_licence) do
+    %(Licenced under the <a href="#{custom_licence_url}">MIT Licence</a>.)
+  end
+  let(:custom_licence_text) { %(Licenced under the MIT Licence) }
+  let(:kwargs) do
+    { licence: custom_licence, copyright_text: custom_copyright, copyright_url: custom_copyright_url }
+  end
+
+  subject! do
+    render_inline(GovukComponent::Footer.new(**kwargs))
   end
 
   context 'when no arguments are supplied' do
-    let(:component) { GovukComponent::Footer.new }
+    subject! { render_inline(GovukComponent::Footer.new) }
 
     specify 'the default licence info is included' do
-      expect(subject).to have_css('footer.govuk-footer .govuk-footer__meta') do
-        expect(page).to have_css('.govuk-footer__licence-description') do
-          expect(page).to have_content(/All content is available under/)
-          expect(page).to have_link("Open Government Licence v3.0", href: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
+      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
+        expect(footer).to have_css('.govuk-footer__licence-description') do |description|
+          expect(description).to have_content(/All content is available under/)
+          expect(description).to have_link("Open Government Licence v3.0", href: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
         end
       end
     end
 
     specify 'the default copyright information is included' do
-      expect(subject).to have_css('footer.govuk-footer .govuk-footer__meta') do
-        expect(page).to have_css('.govuk-footer__meta-item', text: %r{\&copy Crown copyright})
+      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
+        expect(footer).to have_css('.govuk-footer__meta-item', text: %r{\&copy Crown copyright})
       end
     end
 
     specify 'the crown symbol is included' do
-      expect(subject).to have_css('footer.govuk-footer .govuk-footer__meta') do
-        expect(page).to have_css('svg', class: 'govuk-footer__licence-logo')
+      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
+        expect(footer).to have_css('svg', class: 'govuk-footer__licence-logo')
       end
     end
   end
 
   context 'when custom licence and copyright info are supplied' do
-    let(:custom_copyright) { "All rights reserved" }
-    let(:custom_copyright_url) { "https://en.wikipedia.org/wiki/All_rights_reserved" }
-    let(:custom_licence_url) { "https://mit-license.org/" }
-    let(:custom_licence) do
-      %(Licenced under the <a href="#{custom_licence_url}">MIT Licence</a>.)
-    end
-
-    let(:component) { GovukComponent::Footer.new(licence: custom_licence, copyright_text: custom_copyright, copyright_url: custom_copyright_url) }
-
     specify 'the custom licence should have replaced the default' do
-      expect(subject).to have_css('footer.govuk-footer .govuk-footer__meta') do
-        within('.govuk-footer__licence-description') do
-          expect(page).to have_content(custom_licence)
-          expect(page).to have_link("MIT Licence", href: custom_licence_url)
+      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
+        expect(footer).to have_css('.govuk-footer__licence-description') do |description|
+          expect(description).to have_content(custom_licence_text)
+          expect(description).to have_link("MIT Licence", href: custom_licence_url)
 
-          expect(page).not_to content(/All content is available under/)
+          expect(description).not_to have_content(/All content is available under/)
         end
       end
     end
 
     specify 'the custom copyright should have replaced the default' do
-      expect(subject).to have_css('footer.govuk-footer .govuk-footer__meta') do
-        expect(page).to have_css('.govuk-footer__meta-item') do
+      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
+        expect(footer).to have_css('.govuk-footer__meta-item') do
           expect(page).to have_link(custom_copyright, href: custom_copyright_url)
         end
       end
     end
   end
 
-  xcontext 'when custom content is passed in' do
+  context 'when custom content is passed in' do
     let(:content) do
-      capture do
-        content_tag('nav') do
-          concat(tag.h3('Navigation'))
-        end
-      end
+      helper.tag.nav { helper.tag.h3('Navigation') }
     end
-    let(:component) { GovukComponent::Footer.new { content } }
+
+    subject! { render_inline(GovukComponent::Footer.new) { content } }
 
     specify 'the content should be rendered' do
-      expect(subject).to have_css('footer.govuk-footer .govuk-footer__meta') do
-        expect(page).to have_css('nav', text: 'Navigation')
+      expect(page).to have_css('footer.govuk-footer') do |footer|
+        expect(footer).to have_css('nav > h3', text: 'Navigation')
       end
     end
   end
 
   describe 'meta links' do
-    let(:component) { GovukComponent::Footer.new(meta_links: links, meta_heading: heading) }
+    subject! { render_inline(GovukComponent::Footer.new(meta_links: links, meta_heading: heading)) }
 
     context 'when meta links are supplied' do
       let(:heading) { 'Related info' }
@@ -87,15 +88,15 @@ RSpec.describe(GovukComponent::Footer, type: :component) do
         { one: '/one', two: '/two', three: '/three' }
       end
 
-      it { is_expected.to have_css('ul.govuk-footer__inline-list') }
-      it { is_expected.to have_css('h2', class: 'govuk-visually-hidden', text: heading) }
+      specify { expect(page).to have_css('ul.govuk-footer__inline-list') }
+      specify { expect(page).to have_css('h2', class: 'govuk-visually-hidden', text: heading) }
 
       specify 'the meta links should be rendered' do
-        expect(subject).to have_css('footer.govuk-footer .govuk-footer__meta') do
-          expect(page).to have_css('li', class: 'govuk-footer__inline-list-item', count: links.size)
+        expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |meta|
+          expect(meta).to have_css('li', class: 'govuk-footer__inline-list-item', count: links.size)
 
           links.each do |text, href|
-            expect(page).to have_link(text, href: href)
+            expect(meta).to have_link(text, href: href)
           end
         end
       end
@@ -105,8 +106,11 @@ RSpec.describe(GovukComponent::Footer, type: :component) do
       let(:links) { {} }
       let(:heading) { 'This should be absent' }
 
-      it { is_expected.not_to have_css('ul.govuk-footer__inline-list') }
-      it { is_expected.not_to have_css('h2', class: 'govuk-visually-hidden', text: heading) }
+      specify { expect(page).not_to have_css('ul.govuk-footer__inline-list') }
+      specify { expect(page).not_to have_css('h2', class: 'govuk-visually-hidden', text: heading) }
     end
   end
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/header_spec.rb
+++ b/spec/components/govuk_component/header_spec.rb
@@ -90,7 +90,6 @@ RSpec.describe(GovukComponent::Header, type: :component) do
     end
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { described_class }
-  end
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/header_spec.rb
+++ b/spec/components/govuk_component/header_spec.rb
@@ -92,4 +92,13 @@ RSpec.describe(GovukComponent::Header, type: :component) do
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
+
+  context 'slot arguments' do
+    let(:slot) { :item }
+    let(:content) { nil }
+    let(:slot_kwargs) { { title: 'title', href: '/one/two/three', active: true } }
+
+    it_behaves_like 'a component with a slot that accepts custom classes'
+    it_behaves_like 'a component with a slot that accepts custom html attributes'
+  end
 end

--- a/spec/components/govuk_component/inset_text_spec.rb
+++ b/spec/components/govuk_component/inset_text_spec.rb
@@ -12,4 +12,7 @@ RSpec.describe(GovukComponent::InsetText, type: :component) do
   it_behaves_like 'a component that accepts custom classes' do
     let(:component_class) { described_class }
   end
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/panel_spec.rb
+++ b/spec/components/govuk_component/panel_spec.rb
@@ -13,7 +13,6 @@ RSpec.describe(GovukComponent::Panel, type: :component) do
     end
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { described_class }
-  end
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/phase_banner_spec.rb
+++ b/spec/components/govuk_component/phase_banner_spec.rb
@@ -36,4 +36,7 @@ RSpec.describe(GovukComponent::PhaseBanner, type: :component) do
       end
     end
   end
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/start_now_button_spec.rb
+++ b/spec/components/govuk_component/start_now_button_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe(GovukComponent::StartNowButton, type: :component) do
     end
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { described_class }
-  end
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/summary_list_spec.rb
+++ b/spec/components/govuk_component/summary_list_spec.rb
@@ -73,8 +73,7 @@ RSpec.describe(GovukComponent::SummaryList, type: :component) do
     end
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { described_class }
-  end
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end
 

--- a/spec/components/govuk_component/summary_list_spec.rb
+++ b/spec/components/govuk_component/summary_list_spec.rb
@@ -75,5 +75,14 @@ RSpec.describe(GovukComponent::SummaryList, type: :component) do
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
+
+  context 'slot arguments' do
+    let(:slot) { :row }
+    let(:content) { nil }
+    let(:slot_kwargs) { { key: 'key', value: 'value' } }
+
+    it_behaves_like 'a component with a slot that accepts custom classes'
+    it_behaves_like 'a component with a slot that accepts custom html attributes'
+  end
 end
 

--- a/spec/components/govuk_component/tabs_spec.rb
+++ b/spec/components/govuk_component/tabs_spec.rb
@@ -72,7 +72,6 @@ RSpec.describe(GovukComponent::Tabs, type: :component) do
     expect(tab_link_hrefs).to eql(panel_ids)
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { described_class }
-  end
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/govuk_component/tabs_spec.rb
+++ b/spec/components/govuk_component/tabs_spec.rb
@@ -74,4 +74,13 @@ RSpec.describe(GovukComponent::Tabs, type: :component) do
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
+
+  context 'slot arguments' do
+    let(:slot) { :tab }
+    let(:content) { ->{ 'some swanky tab content' } }
+    let(:slot_kwargs) { { title: title } }
+
+    it_behaves_like 'a component with a slot that accepts custom classes'
+    it_behaves_like 'a component with a slot that accepts custom html attributes'
+  end
 end

--- a/spec/components/govuk_component/warning_spec.rb
+++ b/spec/components/govuk_component/warning_spec.rb
@@ -1,36 +1,37 @@
 require 'spec_helper'
 
 RSpec.describe(GovukComponent::Warning, type: :component) do
-  let(:node) { Capybara::Node::Simple.new(render_inline(component).to_html) }
   let(:text) { 'Some warning' }
+  let(:icon_fallback_text) { 'Some warning' }
+  let(:kwargs) { { text: text } }
 
   context 'default behaviour' do
-    let(:component) { GovukComponent::Warning.new(text: text) }
+    before { render_inline(GovukComponent::Warning.new(**kwargs)) }
 
     context 'containing div' do
-      subject { node.find('.govuk-warning-text') }
+      subject { page.find('.govuk-warning-text') }
+
       it { is_expected.to have_css('span', class: 'govuk-warning-text__icon', text: '!') }
     end
 
     context 'strong tag' do
-      subject { node.find('.govuk-warning-text > strong.govuk-warning-text__text') }
+      subject { page.find('.govuk-warning-text > strong.govuk-warning-text__text') }
+
       it { is_expected.to have_css('span', class: 'govuk-warning-text__assistive', text: 'Warning') }
       it { is_expected.to have_text text }
     end
   end
 
   context 'with custom warning text' do
-    let(:icon_fallback_text) { 'Custom fallback text' }
-    let(:component) { GovukComponent::Warning.new(text: text, icon_fallback_text: icon_fallback_text) }
+    before { render_inline(GovukComponent::Warning.new(**kwargs.merge(icon_fallback_text: icon_fallback_text))) }
 
     context 'strong tag' do
-      subject { node.find('.govuk-warning-text > strong.govuk-warning-text__text') }
+      subject { page.find('.govuk-warning-text > strong.govuk-warning-text__text') }
+
       it { is_expected.to have_css('span', class: 'govuk-warning-text__assistive', text: icon_fallback_text) }
     end
   end
 
-  it_behaves_like 'a component that accepts custom classes' do
-    let(:component_class) { GovukComponent::Warning }
-    let(:kwargs) { { text: text } }
-  end
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/shared/a_component_that_accepts_custom_classes.rb
+++ b/spec/components/shared/a_component_that_accepts_custom_classes.rb
@@ -1,5 +1,5 @@
 shared_examples 'a component that accepts custom classes' do
-  subject! { render_inline(component_class.send(:new, **kwargs.merge(classes: custom_classes))) }
+  before { render_inline(described_class.send(:new, **kwargs.merge(classes: custom_classes))) }
 
   context 'when classes are supplied as a string' do
     let(:custom_classes) { 'purple-stripes' }

--- a/spec/components/shared/a_component_that_accepts_custom_html_attributes.rb
+++ b/spec/components/shared/a_component_that_accepts_custom_html_attributes.rb
@@ -1,0 +1,11 @@
+shared_examples 'a component that accepts custom HTML attributes' do
+  let(:custom_attributes) { { lang: "en-GB", style: "background-color: blue;" } }
+
+  subject! { render_inline(described_class.send(:new, html_attributes: custom_attributes, **kwargs)) }
+
+  specify 'the custom HTML attributes should be set correctly' do
+    custom_attributes.each do |key, value|
+      expect(page).to have_css(%(*[#{key}="#{value}"]))
+    end
+  end
+end

--- a/spec/components/shared/a_component_with_a_slot_that_accepts_custom_classes.rb
+++ b/spec/components/shared/a_component_with_a_slot_that_accepts_custom_classes.rb
@@ -1,0 +1,13 @@
+shared_examples 'a component with a slot that accepts custom classes' do
+  let(:custom_class) { 'purple-stripes' }
+
+  subject! do
+    render_inline(described_class.send(:new, **kwargs)) do |component|
+      component.slot(slot, classes: custom_class, **slot_kwargs, &content)
+    end
+  end
+
+  specify 'the rendered slot should have the custom class' do
+    expect(page).to have_css('.' + custom_class)
+  end
+end

--- a/spec/components/shared/a_component_with_a_slot_that_accepts_custom_html_attributes.rb
+++ b/spec/components/shared/a_component_with_a_slot_that_accepts_custom_html_attributes.rb
@@ -1,0 +1,13 @@
+shared_examples 'a component with a slot that accepts custom html attributes' do
+  let(:custom_attributes) { { lang: "en-GB", style: "background-color: blue;" } }
+
+  subject! do
+    render_inline(described_class.send(:new, **kwargs)) do |component|
+      component.slot(slot, html_attributes: custom_attributes, **slot_kwargs, &content)
+    end
+  end
+
+  specify 'the rendered slot should have the HTML attributes' do
+    expect(page).to have_css(custom_attributes.map { |k,v| %([#{k}='#{v}']) }.join)
+  end
+end


### PR DESCRIPTION
Following on from #32, this change allows all the components and their slots to receive `classes:` and `html_attributes:` arguments.

* anything passed to `classes` (either as a `String` or `Array`) will be combined with `default_classes` and added to the outer node
* anything passed to `html_attributes` (as a `Hash`) will be set as HTML attributes on the outer node in the regular Rails fashion `tag.div(**html_attributes) { 'hello world' }`