### PR TITLE
Allow for a more DSL like syntax

### DIFF
--- a/app/components/govuk_component/accordion.rb
+++ b/app/components/govuk_component/accordion.rb
@@ -2,6 +2,7 @@ class GovukComponent::Accordion < GovukComponent::Base
   include ViewComponent::Slotable
 
   with_slot :section, collection: true, class_name: 'Section'
+  wrap_slot :section
 
   attr_accessor :id
 

--- a/app/components/govuk_component/base.rb
+++ b/app/components/govuk_component/base.rb
@@ -6,4 +6,12 @@ class GovukComponent::Base < ViewComponent::Base
     @classes         = parse_classes(classes)
     @html_attributes = html_attributes
   end
+
+  # Redirect #name to #slot(:name) to make building components
+  # with slots feel more DSL-like
+  def self.wrap_slot(name)
+    define_method(name) do |*args, **kwargs, &block|
+      self.slot(name, *args, **kwargs, &block)
+    end
+  end
 end

--- a/app/components/govuk_component/header.rb
+++ b/app/components/govuk_component/header.rb
@@ -4,6 +4,7 @@ class GovukComponent::Header < GovukComponent::Base
   attr_accessor :logo, :logo_href, :service_name, :service_name_href
 
   with_slot :item, collection: true, class_name: 'Item'
+  wrap_slot :item
 
   def initialize(logo: 'GOV.UK', logo_href: '/', service_name: nil, service_name_href: '/', classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)

--- a/app/components/govuk_component/summary_list.rb
+++ b/app/components/govuk_component/summary_list.rb
@@ -2,6 +2,7 @@ class GovukComponent::SummaryList < GovukComponent::Base
   include ViewComponent::Slotable
 
   with_slot :row, collection: true, class_name: 'Row'
+  wrap_slot :row
 
   def any_row_has_actions?
     rows.any? { |r| r.action.present? }

--- a/app/components/govuk_component/tabs.rb
+++ b/app/components/govuk_component/tabs.rb
@@ -4,6 +4,7 @@ class GovukComponent::Tabs < GovukComponent::Base
   attr_accessor :title
 
   with_slot :tab, collection: true, class_name: 'Tab'
+  wrap_slot :tab
 
   def initialize(title:, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)

--- a/app/helpers/govuk_components_helper.rb
+++ b/app/helpers/govuk_components_helper.rb
@@ -1,0 +1,28 @@
+module GovukComponentHelper
+  {
+    govuk_accordion: 'GovukComponent::Accordion',
+    govuk_back_link: 'GovukComponent::BackLink',
+    govuk_breadcrumbs: 'GovukComponent::Breadcrumbs',
+    govuk_details: 'GovukComponent::Details',
+    govuk_footer: 'GovukComponent::Footer',
+    govuk_header: 'GovukComponent::Header',
+    govuk_inset_text: 'GovukComponent::InsetText',
+    govuk_panel: 'GovukComponent::Panel',
+    govuk_phase_banner: 'GovukComponent::PhaseBanner',
+    govuk_start_now_button: 'GovukComponent::StartNowButton',
+    govuk_summary_list: 'GovukComponent::SummaryList',
+    govuk_tabs: 'GovukComponent::Tabs',
+    govuk_tag: 'GovukComponent::Tag',
+    govuk_warning: 'GovukComponent::Warning',
+  }.each do |name, klass|
+    define_method(name) do |*args, **kwargs, &block|
+      capture do
+        render(klass.constantize.new(*args, **kwargs)) do |com|
+          block.call(com) unless block.blank?
+        end
+      end
+    end
+  end
+end
+
+ActiveSupport.on_load(:action_view) { include GovukComponentHelper }

--- a/docs/index.html
+++ b/docs/index.html
@@ -10557,6 +10557,57 @@ end
 </article>
 
 
+<article class="example govuk-!-margin-top-9" id="accordion-(using-the-helper)">
+  <h2 class="govuk-heading-s">Accordion (using the helper)</h2>
+  <section>
+    <div id="def234" class="govuk-accordion" data-module="govuk-accordion">
+    <div id="section-1-section" class="govuk-accordion__section">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span id="section-1" class="govuk-accordion__section-button">Section 1</span>
+        </h2>
+      </div>
+      <div id="section-1-content" class="govuk-accordion__section-content" aria-labelledby="section-1"><p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></div>
+</div>    <div id="section-2-section" class="govuk-accordion__section">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span id="section-2" class="govuk-accordion__section-button">Section 2</span>
+        </h2>
+      </div>
+      <div id="section-2-content" class="govuk-accordion__section-content" aria-labelledby="section-2"><p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></div>
+</div>    <div id="section-3-section" class="govuk-accordion__section">
+      <div class="govuk-accordion__section-header">
+        <h2 class="govuk-accordion__section-heading">
+          <span id="section-3" class="govuk-accordion__section-button">Section 3</span>
+        </h2>
+      </div>
+      <div id="section-3-content" class="govuk-accordion__section-content" aria-labelledby="section-3"><p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></div>
+</div>
+</div>
+  </section>
+  <section>
+    <pre><code class="language-ruby">govuk_accordion(id: 'def234') do |accordion|
+  accordion.section(title: 'Section 1') do
+    tag.p(class: 'govuk-body') do
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    end
+  end
+  accordion.section(title: 'Section 2') do
+    tag.p(class: 'govuk-body') do
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    end
+  end
+  accordion.section(title: 'Section 3') do
+    tag.p(class: 'govuk-body') do
+      "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+    end
+  end
+end
+</code></pre>
+  </section>
+</article>
+
+
       </section>
       <section class="component-example">
         <h2 class="govuk-heading-l" id="back-links">Back links</h2>
@@ -11011,7 +11062,7 @@ end
   <h2 class="govuk-heading-s">Button links</h2>
   <section>
     <form class="button_to" method="post" action="/">
-<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="0koT3++nNgwe2bw9Em9bdL1JUnyhBzaydAsX33NTJv0YNcFhzyKyfLMzWosu/TEQJ/IlEG0lXfSIEbGH8cQXbw==">
+<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="jYL65BF/ryKYQ7CAGUc1S67KZD3Qr9uxDJPpvFBPylIgoIl/K9HUuDG+JCveVkh4kVzHj2SVqGo6wNqVjjMg3A==">
 </form>
   </section>
   <section>

--- a/spec/components/govuk_component/accordion_spec.rb
+++ b/spec/components/govuk_component/accordion_spec.rb
@@ -87,4 +87,11 @@ RSpec.describe(GovukComponent::Accordion, type: :component) do
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'
   end
+
+  it_behaves_like 'a component with a DSL wrapper' do
+    let(:helper_name) { 'govuk_accordion' }
+    let(:wrapped_slots) { %i(section) }
+
+    let(:expected_css) { '.govuk-accordion' }
+  end
 end

--- a/spec/components/govuk_component/header_spec.rb
+++ b/spec/components/govuk_component/header_spec.rb
@@ -101,4 +101,11 @@ RSpec.describe(GovukComponent::Header, type: :component) do
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'
   end
+
+  it_behaves_like 'a component with a DSL wrapper' do
+    let(:helper_name) { 'govuk_header' }
+    let(:wrapped_slots) { %i(item) }
+
+    let(:expected_css) { '.govuk-header' }
+  end
 end

--- a/spec/components/govuk_component/summary_list_spec.rb
+++ b/spec/components/govuk_component/summary_list_spec.rb
@@ -84,5 +84,11 @@ RSpec.describe(GovukComponent::SummaryList, type: :component) do
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'
   end
-end
 
+  it_behaves_like 'a component with a DSL wrapper' do
+    let(:helper_name) { 'govuk_summary_list' }
+    let(:wrapped_slots) { %i(row) }
+
+    let(:expected_css) { '.govuk-summary-list' }
+  end
+end

--- a/spec/components/govuk_component/tabs_spec.rb
+++ b/spec/components/govuk_component/tabs_spec.rb
@@ -83,4 +83,11 @@ RSpec.describe(GovukComponent::Tabs, type: :component) do
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'
   end
+
+  it_behaves_like 'a component with a DSL wrapper' do
+    let(:helper_name) { 'govuk_tabs' }
+    let(:wrapped_slots) { %i(tab) }
+
+    let(:expected_css) { '.govuk-tabs' }
+  end
 end

--- a/spec/components/shared/a_component_with_a_dsl_wrapper.rb
+++ b/spec/components/shared/a_component_with_a_dsl_wrapper.rb
@@ -1,0 +1,25 @@
+shared_examples 'a component with a DSL wrapper' do
+  describe 'wrapping the component', type: 'helper' do
+    let(:action_view_context) { ActionView::LookupContext.new(nil) }
+    let(:helper) { ActionView::Base.new(action_view_context) }
+
+    let(:component) { helper.send(helper_name, **kwargs) }
+    subject { Capybara::Node::Simple.new(component) }
+
+    specify 'renders the component' do
+      expect(subject).to have_css(expected_css)
+    end
+  end
+
+  describe 'wrapping slots' do
+    subject { described_class.new(**kwargs) }
+
+    it { is_expected.to respond_to(:slot) }
+
+    specify 'wraps all specified slots' do
+      wrapped_slots.each do |wrapped_slot|
+        is_expected.to respond_to(wrapped_slot)
+      end
+    end
+  end
+end

--- a/spec/dummy/app/views/demos/examples/_accordion.html.erb
+++ b/spec/dummy/app/views/demos/examples/_accordion.html.erb
@@ -31,3 +31,24 @@
   end
   ACCORDION
 %>
+
+<%= render "shared/example", title: "Accordion (using the helper)", example: <<~ACCORDION
+  govuk_accordion(id: 'def234') do |accordion|
+    accordion.section(title: 'Section 1') do
+      tag.p(class: 'govuk-body') do
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      end
+    end
+    accordion.section(title: 'Section 2') do
+      tag.p(class: 'govuk-body') do
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      end
+    end
+    accordion.section(title: 'Section 3') do
+      tag.p(class: 'govuk-body') do
+        "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
+      end
+    end
+  end
+  ACCORDION
+%>

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -2,28 +2,14 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">GOV.UK Rails Components</h1>
 
-    <%= govuk_tag(text: 'Hi') %>
-
-    <%= govuk_accordion do |component| %>
-      <%= component.slot(:section, title: 'Hello') do %>
-        <p>World</p>
-      <% end %>
-    <% end %>
-
-    <%= govuk_inset_text(text: 'Hi') %>
-
-    <%= govuk_panel(title: 'Hi', body: 'There') %>
-
-    <% if false %>
-      <% Dir
-          .glob(Rails.root.join('app', 'views', 'demos', 'examples', '*.html.erb'))
-          .map { |f| File.basename(f)[%r{_(?<partial>.*)\.html.erb}, %(partial)] }
-          .sort
-          .each do |p| %>
-        <section class="component-example">
-          <%= render %(demos/examples/#{p}) %>
-        </section>
-      <% end %>
+    <% Dir
+        .glob(Rails.root.join('app', 'views', 'demos', 'examples', '*.html.erb'))
+        .map { |f| File.basename(f)[%r{_(?<partial>.*)\.html.erb}, %(partial)] }
+        .sort
+        .each do |p| %>
+      <section class="component-example">
+        <%= render %(demos/examples/#{p}) %>
+      </section>
     <% end %>
 
   </div>

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -2,14 +2,28 @@
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-xl">GOV.UK Rails Components</h1>
 
-    <% Dir
-        .glob(Rails.root.join('app', 'views', 'demos', 'examples', '*.html.erb'))
-        .map { |f| File.basename(f)[%r{_(?<partial>.*)\.html.erb}, %(partial)] }
-        .sort
-        .each do |p| %>
-      <section class="component-example">
-        <%= render %(demos/examples/#{p}) %>
-      </section>
+    <%= govuk_tag(text: 'Hi') %>
+
+    <%= govuk_accordion do |component| %>
+      <%= component.slot(:section, title: 'Hello') do %>
+        <p>World</p>
+      <% end %>
+    <% end %>
+
+    <%= govuk_inset_text(text: 'Hi') %>
+
+    <%= govuk_panel(title: 'Hi', body: 'There') %>
+
+    <% if false %>
+      <% Dir
+          .glob(Rails.root.join('app', 'views', 'demos', 'examples', '*.html.erb'))
+          .map { |f| File.basename(f)[%r{_(?<partial>.*)\.html.erb}, %(partial)] }
+          .sort
+          .each do |p| %>
+        <section class="component-example">
+          <%= render %(demos/examples/#{p}) %>
+        </section>
+      <% end %>
     <% end %>
 
   </div>


### PR DESCRIPTION
This is an experiment that provides a set of helpers, one per component, that _wraps_ the component functionality and will make the code required to render them simpler and (probably) more intuitive. It was driven purely by how I'd want to write templates, so is probably biased and subjective - hence the discussion tag!

It's a two step process, but it should work the same way for any of our components.

First, _register_ the component to be wrapped in the `GovukComponentsHelper`; the key is the helper's name and the value is the component class in a string. This will generate the helper - all the helper does is sends all args through to the component's initializer.

```ruby
  {
    govuk_accordion: 'GovukComponent::Accordion',
    govuk_back_link: 'GovukComponent::BackLink',
    govuk_breadcrumbs: 'GovukComponent::Breadcrumbs',
    ...
  }
```

Second, for components that have slots, we can further improve the API by using the `wrap_slot` macro:

```diff
   attr_accessor :title

   with_slot :tab, collection: true, class_name: 'Tab'
+  wrap_slot :tab

   def initialize(title:, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
```

This allows `#tab` to be called on the tabs component itself, making for clean, minimal syntax. In this snippet we're calling `#section` on the accordion component:

![Screenshot from 2020-08-30 11-26-53](https://user-images.githubusercontent.com/128088/91657092-432a1400-eab6-11ea-9fe2-73e9b832f78a.png)

For what it's worth, the approach resembles that of https://github.com/github/view_component/issues/403 