### PR TITLE
Add column component, specs and use on dummy page

### DIFF
--- a/app/components/govuk_component/layout/column.rb
+++ b/app/components/govuk_component/layout/column.rb
@@ -1,0 +1,39 @@
+class GovukComponent::Layout::Column < GovukComponent::Base
+  WIDTHS = {
+    'full'           => 'govuk-grid-column-full',
+    'one-half'       => 'govuk-grid-column-one-half',
+    'two-thirds'     => 'govuk-grid-column-two-thirds',
+    'one-third'      => 'govuk-grid-column-one-third',
+    'three-quarters' => 'govuk-grid-column-three-quarters',
+    'one-quarter'    => 'govuk-grid-column-one-quarter',
+  }.freeze
+
+  def initialize(width:, from_desktop: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+
+    @width        = width
+    @from_desktop = from_desktop
+  end
+
+  def call
+    tag.div(class: classes.push(width_class, from_desktop_class), **html_attributes) { content }
+  end
+
+private
+
+  def width_class
+    retrieve_width_class(@width)
+  end
+
+  def from_desktop_class
+    return unless @from_desktop.present?
+
+    retrieve_width_class(@from_desktop) + '-from-desktop'
+  end
+
+  def retrieve_width_class(width)
+    WIDTHS.fetch(width)
+  rescue KeyError
+    fail ArgumentError, %(invalid width: #{width}, valid widths are #{WIDTHS.keys.join(",")})
+  end
+end

--- a/app/helpers/govuk_components_helper.rb
+++ b/app/helpers/govuk_components_helper.rb
@@ -3,6 +3,7 @@ module GovukComponentHelper
     govuk_accordion: 'GovukComponent::Accordion',
     govuk_back_link: 'GovukComponent::BackLink',
     govuk_breadcrumbs: 'GovukComponent::Breadcrumbs',
+    govuk_column: 'GovukComponent::Layout::Column',
     govuk_details: 'GovukComponent::Details',
     govuk_footer: 'GovukComponent::Footer',
     govuk_header: 'GovukComponent::Header',

--- a/spec/components/govuk_component/layout/column_spec.rb
+++ b/spec/components/govuk_component/layout/column_spec.rb
@@ -1,0 +1,98 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::Layout::Column, type: :component) do
+  include_context 'helpers'
+  let(:expected_text) { 'Aloha' }
+  let(:content) { helper.tag.span(expected_text) }
+
+  supported_widths = {
+    'full'           => 'govuk-grid-column-full',
+    'one-half'       => 'govuk-grid-column-one-half',
+    'two-thirds'     => 'govuk-grid-column-two-thirds',
+    'one-third'      => 'govuk-grid-column-one-third',
+    'three-quarters' => 'govuk-grid-column-three-quarters',
+    'one-quarter'    => 'govuk-grid-column-one-quarter',
+  }
+
+  let(:supported_widths) { supported_widths }
+
+  context 'when a width is supplied' do
+    let(:kwargs) { { width: 'one-third' } }
+    subject! do
+      render_inline(GovukComponent::Layout::Column.new(**kwargs)) { content }
+    end
+
+    specify 'creates a div containing the provided content' do
+      expect(page).to have_css('div > span', text: expected_text)
+    end
+
+    describe 'valid widths' do
+      supported_widths.each do |name, klass|
+        context %(width: '#{name}') do
+          let(:kwargs) { { width: name } }
+
+          specify %(element should have class #{klass}) do
+            expect(page).to have_css(%(div.#{klass}))
+          end
+        end
+      end
+    end
+
+    it_behaves_like 'a component that accepts custom classes'
+    it_behaves_like 'a component that accepts custom HTML attributes'
+  end
+
+  context 'when a width from desktop is supplied' do
+    let(:kwargs) { { width: 'one-third', from_desktop: 'one-half' } }
+    subject! do
+      render_inline(GovukComponent::Layout::Column.new(**kwargs)) { content }
+    end
+
+    specify 'creates a div containing the provided content' do
+      expect(page).to have_css('div > span', text: expected_text)
+    end
+
+    describe 'valid widths from desktop' do
+      supported_widths.each do |name, klass|
+        context %(from_desktop: '#{name}') do
+          let(:kwargs) { { width: 'one-third', from_desktop: name } }
+          let(:expected_klass) { klass + '-from-desktop' }
+
+          specify %(element should have class #{klass}-from-desktop) do
+            expect(page).to have_css(%(div.#{expected_klass}))
+          end
+        end
+      end
+    end
+  end
+
+  describe 'bad widths' do
+    subject { render_inline(GovukComponent::Layout::Column.new(**kwargs)) }
+
+    context 'when no width is supplied' do
+      let(:kwargs) { {} }
+
+      specify 'raises with an appropriate message' do
+        expect { subject }.to raise_error(/missing keyword/)
+      end
+    end
+
+    context 'when an invalid width is supplied' do
+      let(:invalid_width) { 'four-fifths' }
+      let(:kwargs) { { width: invalid_width } }
+
+      specify 'should raise an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError, /invalid width/)
+      end
+    end
+
+    context 'when an invalid from desktop width is supplied' do
+      let(:invalid_width) { 'four-fifths' }
+      let(:kwargs) { { width: 'one-third', from_desktop: 'nine-eighths' } }
+
+      specify 'should raise an ArgumentError' do
+        expect { subject }.to raise_error(ArgumentError, /invalid width/)
+      end
+    end
+  end
+end

--- a/spec/dummy/app/views/demos/show.html.erb
+++ b/spec/dummy/app/views/demos/show.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-grid-row">
-  <div class="govuk-grid-column-full">
+  <%= govuk_column(width: 'full') do %>
     <h1 class="govuk-heading-xl">GOV.UK Rails Components</h1>
 
     <% Dir
@@ -12,5 +12,5 @@
       </section>
     <% end %>
 
-  </div>
+  <% end %>
 </div>


### PR DESCRIPTION
This is a quick experiment to evaluate the usefulness of more layout-orientated components. These should reduce the 'wordiness' of some of the class names and make the process a bit more intuitive and easier to remember.

This example covers the behaviour of [columns](https://design-system.service.gov.uk/styles/layout/#grid-system) with support for setting `width`, `from-desktop` width and arbitrary extra HTML attributes.

Example usage (Slim):

```slim
.govuk-width-container
  main.govuk-main-wrapper
    .govuk-grid-row
      = govuk_column(width: 'one-half', from_desktop: 'one-third') do
        p.govuk-body column one content
      = govuk_column(width: 'one-half', from_desktop: 'two-thirds') do
        p.govuk-body column two content
```

vs

```html
<div class="govuk-width-container">
  <main class="govuk-main-wrapper">
    <div class="govuk-grid-row">
      <div class="govuk-grid-column-one-half govuk-grid-column-one-third-from-desktop">
        <p class="govuk-body">column one content</p>
      </div>
      <div class="govuk-grid-column-one-half govuk-grid-column-two-thirds-from-desktop">
        <p class="govuk-body">column two content</p>
      </div>
    </div>
  </main>
</div>
```