### PR TITLE
Fix GovukComponentsHelper name throughout

### DIFF
--- a/app/helpers/govuk_components_helper.rb
+++ b/app/helpers/govuk_components_helper.rb
@@ -1,4 +1,4 @@
-module GovukComponentHelper
+module GovukComponentsHelper
   {
     govuk_accordion: 'GovukComponent::Accordion',
     govuk_back_link: 'GovukComponent::BackLink',
@@ -25,4 +25,4 @@ module GovukComponentHelper
   end
 end
 
-ActiveSupport.on_load(:action_view) { include GovukComponentHelper }
+ActiveSupport.on_load(:action_view) { include GovukComponentsHelper }

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -12,7 +12,7 @@ class HelperComponentMapping
   end
 end
 
-RSpec.describe(GovukComponentHelper, type: 'helper') do
+RSpec.describe(GovukComponentsHelper, type: 'helper') do
   let(:action_view_context) { ActionView::LookupContext.new(nil) }
   let(:helper) { ActionView::Base.new(action_view_context) }
 


### PR DESCRIPTION
The switch from GovukComponentHelper to GovukComponentsHelper was incomplete and caused problems when booting the app in production mode.

Fixes #58