### PR TITLE
Fix Gem::Specification homepage

### DIFF
--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.version     = Govuk::Components::VERSION
   spec.authors     = ["DfE developers"]
   spec.email       = ["peter.yates@digital.education.gov.uk"]
-  spec.homepage    = "https://www.github.com/dfe-digital"
+  spec.homepage    = "https://github.com/DFE-Digital/govuk-components"
   spec.summary     = "Lightweight set of reusable GOV.UK Design System components"
   spec.description = "A collection of components intended to ease the building of GOV.UK Design System web applications"
   spec.license     = "MIT"


### PR DESCRIPTION
When this parameter isn't correct, the govuk-components link in Dependabot PRs isn't pointing to the right place:

![image](https://user-images.githubusercontent.com/23801/95421250-fb0fd400-0934-11eb-940e-ef5a17811b08.png)

(is this also why we're not seeing the commit and version history?)