### PR TITLE
Make govuk link and mail helpers take blocks

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -1,10 +1,10 @@
 module GovukLinkHelper
-  def govuk_link_to(*args, **kwargs)
-    link_to(*args, **{ class: 'govuk-link' }.deep_merge(kwargs))
+  def govuk_link_to(*args, **kwargs, &block)
+    link_to(*args, **{ class: 'govuk-link' }.deep_merge(kwargs), &block)
   end
 
-  def govuk_mail_to(*args, **kwargs)
-    mail_to(*args, **{ class: 'govuk-link' }.deep_merge(kwargs))
+  def govuk_mail_to(*args, **kwargs, &block)
+    mail_to(*args, **{ class: 'govuk-link' }.deep_merge(kwargs), &block)
   end
 
   def govuk_button_to(*args, **kwargs)

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -2,6 +2,7 @@ require 'spec_helper'
 
 RSpec.describe(GovukLinkHelper, type: 'helper') do
   include ActionView::Helpers::UrlHelper
+  include ActionView::Context
 
   let(:text) { 'Menu' }
   subject { Capybara::Node::Simple.new(component) }
@@ -32,6 +33,16 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
         expect(subject).to(have_link(text, href: url, class: custom_class))
       end
     end
+
+    context 'when provided with a block' do
+      let(:link_text) { 'Onwards!' }
+      let(:link_html) { tag.span(link_text) }
+      let(:component) { govuk_link_to(url) { link_html } }
+
+      specify 'should render a link containing the block content' do
+        expect(subject).to have_css('a > span', text: link_text)
+      end
+    end
   end
 
   describe '#govuk_mail_to' do
@@ -59,6 +70,16 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify 'has the custom classes' do
         expect(subject).to(have_link(text, href: target, class: custom_class))
+      end
+    end
+
+    context 'when provided with a block' do
+      let(:link_text) { 'Contact us!' }
+      let(:link_html) { tag.span(link_text) }
+      let(:component) { govuk_mail_to(email_address) { link_html } }
+
+      specify 'should render a link containing the block content' do
+        expect(subject).to have_css('a > span', text: link_text)
       end
     end
   end


### PR DESCRIPTION
The `govuk_link_to` and `govuk_mail_to` helpers didn't pass blocks through to their Rails counterparts. This change adds and tests that functionality.

Fixes #65