### PR TITLE
Fix footer link styling for footer license link

### DIFF
--- a/app/components/govuk_component/footer.rb
+++ b/app/components/govuk_component/footer.rb
@@ -29,7 +29,7 @@ private
   end
 
   def default_licence
-    link = link_to("Open Government Licence v3.0", "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
+    link = link_to("Open Government Licence v3.0", "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", class: %w(govuk-footer__link))
 
     raw(%(All content is available under the #{link}, except where otherwise stated))
   end

--- a/spec/components/govuk_component/footer_spec.rb
+++ b/spec/components/govuk_component/footer_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe(GovukComponent::Footer, type: :component) do
       expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
         expect(footer).to have_css('.govuk-footer__licence-description') do |description|
           expect(description).to have_content(/All content is available under/)
-          expect(description).to have_link("Open Government Licence v3.0", href: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/")
+          expect(description).to have_link("Open Government Licence v3.0", {href: "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/", class: "govuk-footer__link"})
         end
       end
     end


### PR DESCRIPTION
I discovered that the footer default license link did not have the proper styling. This was because no classes were being applied to it.

### Currently:
![image](https://user-images.githubusercontent.com/3441519/99445327-501c0e00-2915-11eb-958b-71797ef875e6.png)


### Expected:
![image](https://user-images.githubusercontent.com/3441519/99445341-56aa8580-2915-11eb-8200-037c38731be6.png)
