### PR TITLE
Allow generation of button style links

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -1,6 +1,6 @@
 module GovukLinkHelper
-  def govuk_link_to(*args, **kwargs, &block)
-    link_to(*args, **{ class: 'govuk-link' }.deep_merge(kwargs), &block)
+  def govuk_link_to(*args, button: false, **kwargs, &block)
+    link_to(*args, **{ class: link_class(button) }.deep_merge(kwargs), &block)
   end
 
   def govuk_mail_to(*args, **kwargs, &block)
@@ -9,6 +9,12 @@ module GovukLinkHelper
 
   def govuk_button_to(*args, **kwargs)
     button_to(*args, **{ class: 'govuk-button' }.deep_merge(kwargs))
+  end
+
+private
+
+  def link_class(button)
+    button ? 'govuk-button' : 'govuk-link'
   end
 end
 

--- a/spec/dummy/app/views/demos/examples/_links.html.erb
+++ b/spec/dummy/app/views/demos/examples/_links.html.erb
@@ -1,5 +1,6 @@
 <%= example_heading('Links and buttons') %>
 
 <%= render "shared/example", title: 'Links', example: %{govuk_link_to('Home', '/')} %>
+<%= render "shared/example", title: 'Links styled like buttons', example: %{govuk_link_to('Continue', '/', button: true)} %>
 <%= render "shared/example", title: 'Email links', example: %{govuk_mail_to('Home', 'test@test.org')} %>
-<%= render "shared/example", title: 'Button links', example: %{govuk_button_to('Home', '/')} %>
+<%= render "shared/example", title: 'Button links (this will render a form that POSTs)', example: %{govuk_button_to('Home', '/')} %>

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -43,6 +43,14 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
         expect(subject).to have_css('a > span', text: link_text)
       end
     end
+
+    describe 'generating a button-style link' do
+      let(:component) { govuk_link_to(text, url, button: true) }
+
+      specify 'has the button class' do
+        expect(subject).to(have_link(text, href: url, class: 'govuk-button'))
+      end
+    end
   end
 
   describe '#govuk_mail_to' do


### PR DESCRIPTION
In addition to the `govuk_button_to` helper which renders a form with a `<input type=submit>` element in it, being able to style regular links as GOV.UK buttons is useful. This can now be achieved by adding a `button: true` argument to the `govuk_link_to` helper:

![Screenshot from 2020-12-05 14-31-16](https://user-images.githubusercontent.com/128088/101245709-8e337300-3706-11eb-896a-559d69534678.png)

Fixes #72 