### PR TITLE
Make link and button classes more sensible

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -1,17 +1,23 @@
 module GovukLinkHelper
   def govuk_link_to(*args, button: false, **kwargs, &block)
-    link_to(*args, **{ class: link_class(button) }.deep_merge(kwargs), &block)
+    link_to(*args, **inject_class(kwargs, class_name: link_class(button)), &block)
   end
 
-  def govuk_mail_to(*args, **kwargs, &block)
-    mail_to(*args, **{ class: 'govuk-link' }.deep_merge(kwargs), &block)
+  def govuk_mail_to(*args, button: false, **kwargs, &block)
+    mail_to(*args, **inject_class(kwargs, class_name: link_class(button)), &block)
   end
 
   def govuk_button_to(*args, **kwargs)
-    button_to(*args, **{ class: 'govuk-button' }.deep_merge(kwargs))
+    button_to(*args, **inject_class(kwargs, class_name: 'govuk-button'))
   end
 
 private
+
+  def inject_class(attributes, class_name:)
+    attributes.with_indifferent_access.tap do |attrs|
+      attrs[:class] = Array.wrap(attrs[:class]).prepend(class_name)
+    end
+  end
 
   def link_class(button)
     button ? 'govuk-button' : 'govuk-link'

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -17,11 +17,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       let(:component) { govuk_link_to(text, url, class: custom_class) }
 
       specify 'has the custom classes' do
-        expect(subject).to(have_link(text, href: url, class: [custom_class]))
-      end
-
-      specify 'does not have the default class' do
-        expect(subject).not_to(have_link(text, href: url, class: 'govuk-link'))
+        expect(subject).to(have_link(text, href: url, class: ['govuk-link', custom_class]))
       end
     end
 
@@ -30,7 +26,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       let(:component) { govuk_link_to(text, url, class: custom_class) }
 
       specify 'has the custom classes' do
-        expect(subject).to(have_link(text, href: url, class: custom_class))
+        expect(subject).to(have_link(text, href: url, class: ['govuk-link', custom_class].flatten))
       end
     end
 
@@ -64,11 +60,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       let(:component) { govuk_mail_to(email_address, text, class: custom_class) }
 
       specify 'has the custom classes' do
-        expect(subject).to(have_link(text, href: target, class: [custom_class]))
-      end
-
-      specify 'does not have the default class' do
-        expect(subject).not_to(have_link(text, href: target, class: 'govuk-link'))
+        expect(subject).to(have_link(text, href: target, class: ['govuk-link', custom_class]))
       end
     end
 
@@ -77,7 +69,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       let(:component) { govuk_mail_to(email_address, text, class: custom_class) }
 
       specify 'has the custom classes' do
-        expect(subject).to(have_link(text, href: target, class: custom_class))
+        expect(subject).to(have_link(text, href: target, class: ['govuk-link', custom_class].flatten))
       end
     end
 
@@ -109,11 +101,11 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       let(:component) { govuk_button_to(text, url, class: custom_class) }
 
       specify 'has the custom classes' do
-        expect(subject).to(have_button(text, class: [custom_class]))
+        expect(subject).to(have_button(text, class: ['govuk-button', custom_class].flatten))
       end
 
-      specify 'does not have the default class' do
-        expect(subject).not_to(have_button(text, class: 'govuk-button'))
+      specify 'has the default class' do
+        expect(subject).to(have_button(text, class: 'govuk-button'))
       end
     end
 


### PR DESCRIPTION
Instead of overwriting the required CSS classes when custom ones are provided, add the custom ones to the required one.

Fixes #74