### PR TITLE
Update SimpleCov to 0.20.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,6 +18,8 @@ jobs:
           ruby-version: 2.7.2
 
       - name: Download CodeClimate reporter
+        env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
         run: |
           curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
           chmod +x ./cc-test-reporter
@@ -33,6 +35,7 @@ jobs:
 
       - name: Run RSpec
         env:
+          CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
           SIMPLECOV: '1'
         run: bundle exec rspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -91,7 +91,6 @@ GEM
       activesupport (>= 4.2.0)
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
-    json (2.5.1)
     loofah (2.8.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -201,11 +200,12 @@ GEM
       sprockets (> 3.0)
       sprockets-rails
       tilt
-    simplecov (0.17.1)
+    simplecov (0.20.0)
       docile (~> 1.1)
-      json (>= 1.8, < 3)
-      simplecov-html (~> 0.10.0)
-    simplecov-html (0.10.2)
+      simplecov-html (~> 0.11)
+      simplecov_json_formatter (~> 0.1)
+    simplecov-html (0.12.3)
+    simplecov_json_formatter (0.1.2)
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
@@ -238,7 +238,7 @@ DEPENDENCIES
   rspec-rails
   rubocop-govuk
   sassc-rails
-  simplecov (~> 0.17.1)
+  simplecov (~> 0.20)
   sqlite3
 
 BUNDLED WITH

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -32,6 +32,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec-rails"
   spec.add_development_dependency "rubocop-govuk"
   spec.add_development_dependency "sassc-rails"
-  spec.add_development_dependency("simplecov", "~> 0.17.1")
+  spec.add_development_dependency("simplecov", "~> 0.20")
   spec.add_development_dependency "sqlite3"
 end


### PR DESCRIPTION
This is a bit of a pain because `0.17.1` _is_ compatible with CodeClimate, `0.18.x` and `0.19.x` aren't, but `0.20.0` is. Unfortunately, it might need a bit of tweaking to make it work, hence the failure of dependabot's attempt #83.

Fixes #83.