### PR TITLE
Support notification banner content via blocks

### DIFF
--- a/app/components/govuk_component/notification_banner.html.erb
+++ b/app/components/govuk_component/notification_banner.html.erb
@@ -7,9 +7,13 @@
   <div class="govuk-notification-banner__content">
     <% headings.each do |heading| %>
       <p class="govuk-notification-banner__heading">
-        <%= heading.text %>
-        <% if heading.link_target && heading.link_text %>
-          <%= link_to(heading.link_text, heading.link_target, class: "govuk-notification-banner__link") %>.
+        <% if heading.text.present? %>
+          <%= heading.text %>
+          <% if heading.link_target && heading.link_text %>
+            <%= link_to(heading.link_text, heading.link_target, class: "govuk-notification-banner__link") %>.
+          <% end %>
+        <% else %>
+          <%= heading.content %>
         <% end %>
       </p>
     <% end %>

--- a/app/components/govuk_component/notification_banner.rb
+++ b/app/components/govuk_component/notification_banner.rb
@@ -36,9 +36,9 @@ class GovukComponent::NotificationBanner < GovukComponent::Base
   class Heading < ViewComponent::Slot
     attr_accessor :text, :link_target, :link_text
 
-    def initialize(text:, link_text: nil, link_target: nil)
-      @text = text
-      @link_text = link_text
+    def initialize(text: nil, link_text: nil, link_target: nil)
+      @text        = text
+      @link_text   = link_text
       @link_target = link_target
     end
 

--- a/spec/components/govuk_component/notification_banner_spec.rb
+++ b/spec/components/govuk_component/notification_banner_spec.rb
@@ -55,6 +55,33 @@ RSpec.describe(GovukComponent::NotificationBanner, type: :component) do
       end
     end
 
+    describe "custom HTML heading content" do
+      let(:heading_text) { "What a nice heading" }
+      before do
+        render_inline(GovukComponent::NotificationBanner.new(**kwargs)) do |nb|
+          nb.slot(:heading) { heading_text }
+        end
+      end
+
+      specify "the title has the custom content" do
+        expect(subject).to have_css("p", text: heading_text)
+      end
+
+      context "when custom HTML and heading text is provided" do
+        let(:block_content) { "should not be rendered" }
+        before do
+          render_inline(GovukComponent::NotificationBanner.new(**kwargs)) do |nb|
+            nb.slot(:heading, text: heading_text) { block_content }
+          end
+        end
+
+        specify "the text should take precedence over the block" do
+          expect(subject).to have_css("p", text: heading_text)
+          expect(subject).not_to have_content(block_content)
+        end
+      end
+    end
+
     describe "when disable_auto_focus is true" do
       let(:custom_id) { 'my-id' }
       let(:kwargs) { { title: title, disable_auto_focus: true } }

--- a/spec/dummy/app/views/demos/examples/_notification_banner.html.erb
+++ b/spec/dummy/app/views/demos/examples/_notification_banner.html.erb
@@ -4,7 +4,7 @@
   render GovukComponent::NotificationBanner.new(title: 'Information', disable_auto_focus: true) do |notification_banner|
     notification_banner.slot(
       :heading,
-      text: 'Very important information',
+      text: 'Very important information.',
       link_text: "Find out more",
       link_target: "#"
     )
@@ -20,7 +20,7 @@
     notification_banner.slot(:heading, text: 'Something excellent happened')
     notification_banner.slot(
       :heading,
-      text: 'Many excellent things happened',
+      text: 'Many excellent things happened.',
       link_text: "See them all",
       link_target: "#"
     )

--- a/spec/dummy/app/views/demos/examples/_notification_banner.html.erb
+++ b/spec/dummy/app/views/demos/examples/_notification_banner.html.erb
@@ -8,6 +8,9 @@
       link_text: "Find out more",
       link_target: "#"
     )
+    notification_banner.slot(:heading) do
+      ["Any content can", tag.em("be passed in"), "via a block" ].join(" ").html_safe
+    end
   end
   NOTIFICATION_BANNER
 %>


### PR DESCRIPTION
This gives the user the option between using structured arguments and just passing in text and link information vs providing the heading with a chunk of HTML that will be rendered within the `p.govuk-notification-banner__heading`.

![Screenshot from 2021-01-08 09-24-35](https://user-images.githubusercontent.com/128088/103997767-63b85800-5193-11eb-92d3-7dffb6dc8a81.png)
