### PR TITLE
Make the footer more flexible

### DIFF
--- a/app/components/govuk_component/footer.html.erb
+++ b/app/components/govuk_component/footer.html.erb
@@ -15,12 +15,16 @@
             <% end %>
           </ul>
         <% end %>
-        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-        </svg>
-        <span class="govuk-footer__licence-description">
-          <%= licence %>
-        </span>
+
+        <% if show_licence? %>
+          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+          </svg>
+
+          <span class="govuk-footer__licence-description">
+            <%= licence %>
+          </span>
+        <% end %>
       </div>
       <div class="govuk-footer__meta-item">
         <%= @copyright %>

--- a/app/components/govuk_component/footer.html.erb
+++ b/app/components/govuk_component/footer.html.erb
@@ -8,30 +8,32 @@
         <%= meta_content.content %>
       <% end %>
 
-      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <% if @meta_links.any? %>
-          <%= @meta_heading %>
-          <ul class="govuk-footer__inline-list">
-            <% @meta_links.each do |meta_link| %>
-              <li class="govuk-footer__inline-list-item">
-                <%= meta_link %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
+      <% if meta_links.any? || show_licence? %>
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <% if meta_links.any? %>
+            <%= meta_heading %>
+            <ul class="govuk-footer__inline-list">
+              <% meta_links.each do |meta_link| %>
+                <li class="govuk-footer__inline-list-item">
+                  <%= meta_link %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
 
-        <% if show_licence? %>
-          <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-            <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-          </svg>
+          <% if show_licence? %>
+            <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+            </svg>
 
-          <span class="govuk-footer__licence-description">
-            <%= licence %>
-          </span>
+            <span class="govuk-footer__licence-description">
+              <%= licence %>
+            </span>
+          <% end %>
+        </div>
         <% end %>
-      </div>
       <div class="govuk-footer__meta-item">
-        <%= @copyright %>
+        <%= copyright %>
       </div>
     </div>
   </div>

--- a/app/components/govuk_component/footer.html.erb
+++ b/app/components/govuk_component/footer.html.erb
@@ -4,6 +4,10 @@
       <%= content %>
     <% end %>
     <div class="govuk-footer__meta">
+      <% if meta_content %>
+        <%= meta_content.content %>
+      <% end %>
+
       <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
         <% if @meta_links.any? %>
           <%= @meta_heading %>

--- a/app/components/govuk_component/footer.rb
+++ b/app/components/govuk_component/footer.rb
@@ -4,7 +4,7 @@ class GovukComponent::Footer < GovukComponent::Base
   with_slot :meta_content, class_name: "MetaContent"
   wrap_slot :meta_content
 
-  attr_accessor :meta, :licence, :copyright, :show_licence
+  attr_accessor :meta, :licence, :copyright, :show_licence, :meta_links, :meta_heading
 
   def initialize(meta_links: nil, meta_heading: default_meta_heading, licence: nil, copyright_text: default_copright_text, copyright_url: default_copyright_url, classes: [], html_attributes: {}, show_licence: true)
     super(classes: classes, html_attributes: html_attributes)

--- a/app/components/govuk_component/footer.rb
+++ b/app/components/govuk_component/footer.rb
@@ -1,4 +1,9 @@
 class GovukComponent::Footer < GovukComponent::Base
+  include ViewComponent::Slotable
+
+  with_slot :meta_content, class_name: "MetaContent"
+  wrap_slot :meta_content
+
   attr_accessor :meta, :licence, :copyright, :show_licence
 
   def initialize(meta_links: nil, meta_heading: default_meta_heading, licence: nil, copyright_text: default_copright_text, copyright_url: default_copyright_url, classes: [], html_attributes: {}, show_licence: true)
@@ -50,4 +55,6 @@ private
   def default_copyright_url
     "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
   end
+
+  class MetaContent < ViewComponent::Slot; end
 end

--- a/app/components/govuk_component/footer.rb
+++ b/app/components/govuk_component/footer.rb
@@ -1,13 +1,18 @@
 class GovukComponent::Footer < GovukComponent::Base
-  attr_accessor :meta, :licence, :copyright
+  attr_accessor :meta, :licence, :copyright, :show_licence
 
-  def initialize(meta_links: nil, meta_heading: default_meta_heading, licence: nil, copyright_text: default_copright_text, copyright_url: default_copyright_url, classes: [], html_attributes: {})
+  def initialize(meta_links: nil, meta_heading: default_meta_heading, licence: nil, copyright_text: default_copright_text, copyright_url: default_copyright_url, classes: [], html_attributes: {}, show_licence: true)
     super(classes: classes, html_attributes: html_attributes)
 
     @meta_links   = build_meta_links(meta_links)
     @meta_heading = raw(tag.h2(meta_heading, class: 'govuk-visually-hidden'))
     @licence      = raw(licence).presence || default_licence
     @copyright    = build_copyright(copyright_text, copyright_url)
+    @show_licence = show_licence
+  end
+
+  def show_licence?
+    show_licence
   end
 
 private

--- a/spec/components/govuk_component/footer_spec.rb
+++ b/spec/components/govuk_component/footer_spec.rb
@@ -78,6 +78,25 @@ RSpec.describe(GovukComponent::Footer, type: :component) do
     end
   end
 
+  context 'when custom meta content is passed in' do
+    let(:meta_text) { 'Meta content goes here' }
+    let(:content) do
+      helper.tag.nav { helper.tag.h3(meta_text) }
+    end
+
+    subject! do
+      render_inline(GovukComponent::Footer.new(**kwargs)) do |component|
+        component.slot(:meta_content) { content }
+      end
+    end
+
+    specify 'the content should be rendered' do
+      expect(page).to have_css('footer.govuk-footer') do |footer|
+        expect(footer).to have_content(meta_text)
+      end
+    end
+  end
+
   describe 'meta links' do
     subject! { render_inline(GovukComponent::Footer.new(meta_links: links, meta_heading: heading)) }
 
@@ -120,4 +139,10 @@ RSpec.describe(GovukComponent::Footer, type: :component) do
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
+  it_behaves_like 'a component with a DSL wrapper' do
+    let(:helper_name) { :govuk_footer }
+    let(:wrapped_slots) { %i(meta_content) }
+    let(:block) { nil }
+    let(:expected_css) { ".govuk-footer" }
+  end
 end

--- a/spec/components/govuk_component/footer_spec.rb
+++ b/spec/components/govuk_component/footer_spec.rb
@@ -133,8 +133,16 @@ RSpec.describe(GovukComponent::Footer, type: :component) do
   context 'when the licence is suppressed' do
     let(:kwargs) { { show_licence: false } }
 
-    specify { expect(page).not_to have_css("govuk-footer__licence-logo") }
-    specify { expect(page).not_to have_css("govuk-footer__licence-description") }
+    specify { expect(page).not_to have_css(".govuk-footer__licence-logo") }
+    specify { expect(page).not_to have_css(".govuk-footer__licence-description") }
+
+    context 'when there are no meta_links either' do
+      let(:kwargs) { { meta_links: [], show_licence: false } }
+
+      specify "the copyright information is the only meta item rendered" do
+        expect(page).to have_css(".govuk-footer__meta-item", count: 1)
+      end
+    end
   end
 
   it_behaves_like 'a component that accepts custom classes'

--- a/spec/components/govuk_component/footer_spec.rb
+++ b/spec/components/govuk_component/footer_spec.rb
@@ -111,6 +111,13 @@ RSpec.describe(GovukComponent::Footer, type: :component) do
     end
   end
 
+  context 'when the licence is suppressed' do
+    let(:kwargs) { { show_licence: false } }
+
+    specify { expect(page).not_to have_css("govuk-footer__licence-logo") }
+    specify { expect(page).not_to have_css("govuk-footer__licence-description") }
+  end
+
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
 end


### PR DESCRIPTION
This change adds two features to the footer:

* The ability to suppress the licence information (both logo and text) by passing in `show_licence: false` 
* A slot called `meta_content` that allows arbitrary HTML to be placed inside the `.govuk-footer__meta` element. There's already a regular `content` tag that allows content to be placed outside the meta container.