### PR TITLE
Reimplement footer

### DIFF
--- a/app/components/govuk_component/footer.html.erb
+++ b/app/components/govuk_component/footer.html.erb
@@ -1,30 +1,42 @@
 <%= tag.footer(class: classes, role: 'contentinfo', **html_attributes) do %>
   <div class="govuk-width-container ">
-    <% if content.present? %>
-      <%= content %>
-    <% end %>
     <div class="govuk-footer__meta">
-      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-        <% if @meta_links.any? %>
-          <%= @meta_heading %>
-          <ul class="govuk-footer__inline-list">
-            <% @meta_links.each do |meta_link| %>
-              <li class="govuk-footer__inline-list-item">
-                <%= meta_link %>
-              </li>
-            <% end %>
-          </ul>
-        <% end %>
-        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
-          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
-        </svg>
-        <span class="govuk-footer__licence-description">
-          <%= licence %>
-        </span>
-      </div>
-      <div class="govuk-footer__meta-item">
-        <%= @copyright %>
-      </div>
+      <% if meta.present? %>
+        <%= meta.content %>
+      <% else %>
+        <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+          <% if meta_items.any? %>
+            <h2 class="govuk-visually-hidden"><%= meta_items_title %></h2>
+
+            <ul class="govuk-footer__inline-list">
+              <% @meta_items.each do |hyperlink| %>
+                <li class="govuk-footer__inline-list-item">
+                  <%= hyperlink %>
+                </li>
+              <% end %>
+            </ul>
+          <% end %>
+
+          <% if meta_licence.nil? %>
+            <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewbox="0 0 483.2 195.7" height="17" width="41">
+              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+            </svg>
+
+            <%= tag.span(default_licence, class: "govuk-footer__licence-description") %>
+          <% elsif meta_licence.present? %>
+            <%= tag.span(meta_licence, class: "govuk-footer__licence-description") %>
+          <% end %>
+
+          <% if meta_content.present? %>
+            <%= meta_content.content %>
+          <% end %>
+        </div>
+        <div class="govuk-footer__meta">
+          <div class="govuk-footer__meta-item">
+            <%= copyright %>
+          </div>
+        </div>
+      <% end %>
     </div>
   </div>
 <% end %>

--- a/app/components/govuk_component/footer.rb
+++ b/app/components/govuk_component/footer.rb
@@ -1,13 +1,21 @@
 class GovukComponent::Footer < GovukComponent::Base
-  attr_accessor :meta, :licence, :copyright
+  include ViewComponent::Slotable
 
-  def initialize(meta_links: nil, meta_heading: default_meta_heading, licence: nil, copyright_text: default_copright_text, copyright_url: default_copyright_url, classes: [], html_attributes: {})
+  with_slot :meta_content
+  wrap_slot :meta_content
+
+  with_slot :meta
+  wrap_slot :meta
+
+  attr_accessor :meta_items, :meta_items_title, :meta_licence, :copyright
+
+  def initialize(meta_items: {}, meta_items_title: "Support links", meta_licence: nil, classes: [], html_attributes: {}, copyright_text: default_copright_text, copyright_url: default_copyright_url)
     super(classes: classes, html_attributes: html_attributes)
 
-    @meta_links   = build_meta_links(meta_links)
-    @meta_heading = raw(tag.h2(meta_heading, class: 'govuk-visually-hidden'))
-    @licence      = raw(licence).presence || default_licence
-    @copyright    = build_copyright(copyright_text, copyright_url)
+    @meta_items       = build_meta_links(meta_items)
+    @meta_items_title = meta_items_title
+    @meta_licence     = meta_licence
+    @copyright        = build_copyright(copyright_text, copyright_url)
   end
 
 private
@@ -22,10 +30,6 @@ private
     fail(ArgumentError, 'meta links must be a hash') unless links.is_a?(Hash)
 
     links.map { |text, href| raw(link_to(text, href, class: %w(govuk-footer__link))) }
-  end
-
-  def default_meta_heading
-    'Supporting links'
   end
 
   def default_licence

--- a/spec/components/govuk_component/footer_spec.rb
+++ b/spec/components/govuk_component/footer_spec.rb
@@ -3,24 +3,22 @@ require 'spec_helper'
 RSpec.describe(GovukComponent::Footer, type: :component) do
   include_context 'helpers'
 
-  let(:custom_copyright) { "All rights reserved" }
-  let(:custom_copyright_url) { "https://en.wikipedia.org/wiki/All_rights_reserved" }
-  let(:custom_licence_url) { "https://mit-license.org/" }
-  let(:custom_licence) do
-    %(Licenced under the <a href="#{custom_licence_url}">MIT Licence</a>.)
-  end
-  let(:custom_licence_text) { %(Licenced under the MIT Licence) }
-  let(:kwargs) do
-    { licence: custom_licence, copyright_text: custom_copyright, copyright_url: custom_copyright_url }
+  let(:custom_content) { "The quick brown fox" }
+  let(:heading_text) { "Some title" }
+  let(:kwargs) { {} }
+  let(:meta_items_title) { 'Useful things' }
+  let(:meta_licence) { 'MIT' }
+  let(:selector) { "footer.govuk-footer .govuk-width-container .govuk-footer__meta" }
+
+  let(:meta_items) do
+    { one: '/one', two: '/two', three: '/three' }
   end
 
   subject! do
     render_inline(GovukComponent::Footer.new(**kwargs))
   end
 
-  context 'when no arguments are supplied' do
-    subject! { render_inline(GovukComponent::Footer.new) }
-
+  describe "when no arguments are provided" do
     specify 'the default licence info is included' do
       expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
         expect(footer).to have_css('.govuk-footer__licence-description') do |description|
@@ -30,84 +28,124 @@ RSpec.describe(GovukComponent::Footer, type: :component) do
       end
     end
 
-    specify 'the default copyright information is included' do
-      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
-        expect(footer).to have_css('.govuk-footer__meta-item', text: %r{\&copy Crown copyright})
-      end
+    specify 'the OGL logo is present' do
+      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta svg')
     end
 
-    specify 'the crown symbol is included' do
-      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
-        expect(footer).to have_css('svg', class: 'govuk-footer__licence-logo')
-      end
+    specify "the copyright information is present" do
+      expect(page).to have_css([selector, ".govuk-footer__meta-item"].join(" "), text: /Crown copyright/)
+      expect(page).to have_css([selector, ".govuk-footer__meta-item .govuk-footer__link.govuk-footer__copyright-logo"].join(" "))
     end
   end
 
-  context 'when custom licence and copyright info are supplied' do
-    specify 'the custom licence should have replaced the default' do
-      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
-        expect(footer).to have_css('.govuk-footer__licence-description') do |description|
-          expect(description).to have_content(custom_licence_text)
-          expect(description).to have_link("MIT Licence", href: custom_licence_url)
+  describe "custom meta contents" do
+    let(:list_selector) { [selector, ".govuk-footer__inline-list"].join(" ") }
 
-          expect(description).not_to have_content(/All content is available under/)
+    describe "meta items and title" do
+      let(:heading_selector) { [selector, "h2.govuk-visually-hidden"].join(" ") }
+
+      context "when no meta_items are present" do
+        let(:kwargs) { { meta_items_title: heading_text } }
+
+        specify "no title should be rendered" do
+          expect(page).not_to have_css(heading_selector, text: heading_text)
+        end
+
+        specify "no list should be rendered" do
+          expect(page).not_to have_css(list_selector)
         end
       end
-    end
 
-    specify 'the custom copyright should have replaced the default' do
-      expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |footer|
-        expect(footer).to have_css('.govuk-footer__meta-item') do
-          expect(page).to have_link(custom_copyright, href: custom_copyright_url)
+      context "when meta_items are present" do
+        let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
+        let(:link_selector) { [selector, ".govuk-footer__inline-list", ".govuk-footer__inline-list-item a"].join(" ") }
+
+        specify "the title should be rendered but visually hidden" do
+          expect(page).to have_css(heading_selector, text: heading_text)
         end
-      end
-    end
-  end
 
-  context 'when custom content is passed in' do
-    let(:content) do
-      helper.tag.nav { helper.tag.h3('Navigation') }
-    end
+        specify "each of the provided links is rendered in a list" do
+          expect(page).to have_css(link_selector, count: meta_items.size)
 
-    subject! { render_inline(GovukComponent::Footer.new) { content } }
-
-    specify 'the content should be rendered' do
-      expect(page).to have_css('footer.govuk-footer') do |footer|
-        expect(footer).to have_css('nav > h3', text: 'Navigation')
-      end
-    end
-  end
-
-  describe 'meta links' do
-    subject! { render_inline(GovukComponent::Footer.new(meta_links: links, meta_heading: heading)) }
-
-    context 'when meta links are supplied' do
-      let(:heading) { 'Related info' }
-
-      let(:links) do
-        { one: '/one', two: '/two', three: '/three' }
-      end
-
-      specify { expect(page).to have_css('ul.govuk-footer__inline-list') }
-      specify { expect(page).to have_css('h2', class: 'govuk-visually-hidden', text: heading) }
-
-      specify 'the meta links should be rendered' do
-        expect(page).to have_css('footer.govuk-footer .govuk-footer__meta') do |meta|
-          expect(meta).to have_css('li', class: 'govuk-footer__inline-list-item', count: links.size)
-
-          links.each do |text, href|
-            expect(meta).to have_link(text, href: href)
+          meta_items.each do |text, href|
+            expect(page).to have_link(text, href: href)
           end
         end
       end
     end
 
-    context 'when no meta links are supplied' do
-      let(:links) { {} }
-      let(:heading) { 'This should be absent' }
+    describe "when custom meta_licence text is provided" do
+      let(:licence_text) { "Permission is hereby granted, free of charge, to any person obtaining a copy of this software" }
+      let(:kwargs) { { meta_licence: licence_text } }
+      let(:licence_selector) { [selector, ".govuk-footer__licence-description"].join(" ") }
 
-      specify { expect(page).not_to have_css('ul.govuk-footer__inline-list') }
-      specify { expect(page).not_to have_css('h2', class: 'govuk-visually-hidden', text: heading) }
+      specify "the custom licence text should be rendered" do
+        expect(page).to have_css(licence_selector, text: licence_text)
+      end
+
+      specify "the licence SVG is not rendered" do
+        expect(page).not_to have_css('footer.govuk-footer .govuk-footer__meta svg')
+      end
+    end
+
+    describe "when custom meta_licence text is disabled with nil" do
+      let(:kwargs) { { meta_licence: false } }
+      let(:licence_selector) { [selector, ".govuk-footer__licence-description"].join(" ") }
+
+      specify "the licence text not should be rendered" do
+        expect(page).not_to have_css(licence_selector)
+      end
+    end
+
+    describe "adding custom content under the meta items list" do
+      let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
+
+      subject! do
+        render_inline(GovukComponent::Footer.new(**kwargs)) do |footer|
+          footer.slot(:meta_content) { custom_content }
+        end
+      end
+
+      specify "the content should be rendered" do
+        expect(page).to have_css(selector, text: custom_content)
+      end
+
+      specify "the licence, meta items and header should still be rendered" do
+        expect(page).to have_css([selector, "h2"].join(" "))
+        expect(page).to have_css([selector, ".govuk-footer__inline-list"].join(" "))
+        expect(page).to have_css([selector, ".govuk-footer__licence-description"].join(" "))
+      end
+    end
+  end
+
+  describe "overwriting all meta information with custom content" do
+    let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
+
+    subject! do
+      render_inline(GovukComponent::Footer.new(**kwargs)) do |footer|
+        footer.slot(:meta) { custom_content }
+      end
+    end
+
+    specify "the custom content should be rendered" do
+      expect(page).to have_css(selector, text: custom_content)
+    end
+
+    specify "the licence, meta items and header shouldn't be rendered" do
+      expect(page).not_to have_css([selector, "h2"].join(" "))
+      expect(page).not_to have_css([selector, ".govuk-footer__inline-list"].join(" "))
+      expect(page).not_to have_css([selector, ".govuk-footer__licence-description"].join(" "))
+    end
+  end
+
+  describe "when custom copyright information is provided" do
+    let(:copyright_text) { "Copyright goes here" }
+    let(:copyright_url) { "https://www.copyright.info" }
+    let(:kwargs) { { copyright_text: copyright_text, copyright_url: copyright_url } }
+
+    specify "the custom copyright text and link are rendered" do
+      expect(page).to have_css([selector, ".govuk-footer__meta-item"].join(" "), text: Regexp.new(copyright_text))
+      expect(page).to have_link(copyright_text, href: copyright_url)
     end
   end
 

--- a/spec/dummy/app/views/demos/examples/_footer.html.erb
+++ b/spec/dummy/app/views/demos/examples/_footer.html.erb
@@ -5,20 +5,23 @@
   FOOTER
 %>
 
-<%= render "shared/example", title: 'Footer with custom text', example: <<~FOOTER
+<%= render "shared/example", title: 'Footer with licence, copyright text and URL', example: <<~FOOTER
   render GovukComponent::Footer.new(
-    licence: 'Custom licence',
+    meta_licence: 'Custom licence',
     copyright_text: 'Custom copyright',
     copyright_url: 'https://design-system.service.gov.uk/')
   FOOTER
 %>
 
-<%= render "shared/example", title: 'Footer with meta links', example: <<~FOOTER
+<%= render "shared/example", title: 'Footer with no licence and some alternative content', example: <<~FOOTER
   render GovukComponent::Footer.new(
-    meta_links: {
+    meta_items: {
       One: "/one",
       Two: "/two"
     },
-    meta_heading: 'Supporting links')
+    meta_licence: false,
+    meta_items_title: 'Supporting links') do |footer|
+      footer.slot(:meta_content) { "The quick brown fox jumped over the lazy dog" }
+    end
   FOOTER
 %>


### PR DESCRIPTION
This is a reimplementation of the footer component built using @paulrobertlloyd's suggestions in #92 


> * `meta_items`: Array. items for use in the meta section of the footer.
> * `meta_items_title`: String. Title for a meta item section. Defaults to ‘Support links’
> * `meta_content`: Slot? Content to add to the meta section of the footer. This will appear below any links specified using `meta_items` option.
> * `meta_licence`: String/Boolean. Licence text. Defaults to OGL licence (OGL logo plus the text ‘All content is available under the Open Government Licence v3.0, except where otherwise stated’). If this option is used, the OGL SVG logo is removed. If set to `false`, both the SVG logo and text span are removed.
> * `meta`: Slot. Custom HTML that appears to the left of the crest. If this slot is used, all of the above settings are ignored, and defaults overwritten.

Here's the spec output describing the new behavoiur

```
GovukComponent::Footer
  when no arguments are provided
    the default licence info is included
    the OGL logo is present
    the copyright information is present
  custom meta contents
    meta items and title
      when no meta_items are present
        no title should be rendered
        no list should be rendered
      when meta_items are present
        the title should be rendered but visually hidden
        each of the provided links is rendered in a list
    when custom meta_licence text is provided
      the custom licence text should be rendered
      the licence SVG is not rendered
    when custom meta_licence text is disabled with nil
      the licence text not should be rendered
    adding custom content under the meta items list
      the content should be rendered
      the licence, meta items and header should still be rendered
  overwriting all meta information with custom content
    the custom content should be rendered
    the licence, meta items and header shouldn't be rendered
  when custom copyright information is provided
    the custom copyright text and link are rendered

```


Fixes #92 
Closes #94 