### PR TITLE
Fix bug preventing role from being set

### DIFF
--- a/app/components/govuk_component/notification_banner.html.erb
+++ b/app/components/govuk_component/notification_banner.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: classes.append(success_class).compact, **html_attributes, role: "region", aria: { labelledby: title_id }, data: data_params) do %>
+<%= tag.div(class: classes.append(success_class).compact, role: "region", aria: { labelledby: title_id }, data: data_params, **html_attributes) do %>
   <div class="govuk-notification-banner__header">
     <%= content_tag(title_tag, class: "govuk-notification-banner__title", id: title_id) do %>
       <%= title %>

--- a/spec/components/govuk_component/notification_banner_spec.rb
+++ b/spec/components/govuk_component/notification_banner_spec.rb
@@ -170,6 +170,23 @@ RSpec.describe(GovukComponent::NotificationBanner, type: :component) do
       end
     end
 
+    describe "custom html attributes" do
+      before do
+        render_inline(described_class.send(:new, **kwargs)) do |nb|
+          nb.slot(:heading, text: "A title")
+        end
+      end
+
+      describe "overriding the role" do
+        let(:custom_role) { "alert" }
+        let(:kwargs) { { title: title, html_attributes: { role: custom_role } } }
+
+        specify 'does the thing' do
+          expect(page).to have_css("div.govuk-notification-banner[role='#{custom_role}']")
+        end
+      end
+    end
+
     it_behaves_like 'a component with a DSL wrapper' do
       let(:helper_name) { 'govuk_notification_banner' }
       let(:wrapped_slots) { %i(heading) }


### PR DESCRIPTION
This occurs because `**html_attributes` was before role in the tag helper's list of arguments, causing `role: 'region'` to overwrite anything that's set via HTML attributes.

Also add a spec to ensure it's working properly

Fixes #109