### PR TITLE
Add `expanded` option to accordion slots

### DIFF
--- a/app/components/govuk_component/accordion.html.erb
+++ b/app/components/govuk_component/accordion.html.erb
@@ -3,7 +3,7 @@
     <%= tag.div(id: section.id(suffix: 'section'), class: section.classes, **section.html_attributes) do %>
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-          <%= tag.span(section.title, id: section.id, class: "govuk-accordion__section-button") %>
+          <%= tag.span(section.title, id: section.id, class: "govuk-accordion__section-button", aria: { expanded: section.expanded? }) %>
         </h2>
         <% if section.summary.present? %>
           <%= tag.div(section.summary, id: section.id(suffix: 'summary'), class: %w(govuk-accordion__section-summary govuk-body)) %>

--- a/app/components/govuk_component/accordion.rb
+++ b/app/components/govuk_component/accordion.rb
@@ -19,17 +19,24 @@ private
   end
 
   class Section < GovukComponent::Slot
-    attr_accessor :title, :summary
+    attr_accessor :title, :summary, :expanded
 
-    def initialize(title:, summary: nil, classes: [], html_attributes: {})
+    alias_method :expanded?, :expanded
+
+    def initialize(title:, summary: nil, expanded: false, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
       self.title   = title
       self.summary = summary
+      self.expanded = expanded
     end
 
     def id(suffix: nil)
       [title.parameterize, suffix].compact.join('-')
+    end
+
+    def classes
+      super + (expanded? ? %w(govuk-accordion__section--expanded) : [])
     end
 
   private

--- a/docs/index.html
+++ b/docs/index.html
@@ -914,98 +914,6 @@
   border-bottom: 1px solid #b1b4b6;
 }
 
-/* line 12, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-.govuk-button-group {
-  margin-bottom: 5px;
-  display: -webkit-box;
-  display: -ms-flexbox;
-  display: flex;
-  -webkit-box-orient: vertical;
-  -webkit-box-direction: normal;
-  -ms-flex-direction: column;
-  flex-direction: column;
-  -webkit-box-align: center;
-  -ms-flex-align: center;
-  align-items: center;
-}
-
-@media (min-width: 40.0625em) {
-  /* line 12, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-  .govuk-button-group {
-    margin-bottom: 15px;
-  }
-}
-
-/* line 48, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-.govuk-button-group .govuk-link {
-  font-family: "GDS Transport", arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.1875;
-  display: inline-block;
-  max-width: 100%;
-  margin-top: 5px;
-  margin-bottom: 20px;
-  text-align: center;
-}
-
-@media print {
-  /* line 48, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-  .govuk-button-group .govuk-link {
-    font-family: sans-serif;
-  }
-}
-
-@media (min-width: 40.0625em) {
-  /* line 48, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-  .govuk-button-group .govuk-link {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1;
-  }
-}
-
-@media print {
-  /* line 48, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-  .govuk-button-group .govuk-link {
-    font-size: 14pt;
-    line-height: 19px;
-  }
-}
-
-/* line 61, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-.govuk-button-group .govuk-button {
-  margin-bottom: 17px;
-}
-
-@media (min-width: 40.0625em) {
-  /* line 12, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-  .govuk-button-group {
-    margin-right: -15px;
-    -webkit-box-orient: horizontal;
-    -webkit-box-direction: normal;
-    -ms-flex-direction: row;
-    flex-direction: row;
-    -ms-flex-wrap: wrap;
-    flex-wrap: wrap;
-    -webkit-box-align: baseline;
-    -ms-flex-align: baseline;
-    align-items: baseline;
-  }
-  /* line 84, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-  .govuk-button-group .govuk-button,
-.govuk-button-group .govuk-link {
-    margin-right: 15px;
-  }
-  /* line 89, node_modules/govuk-frontend/govuk/objects/_button-group.scss */
-  .govuk-button-group .govuk-link {
-    text-align: left;
-  }
-}
-
 /* line 4, node_modules/govuk-frontend/govuk/objects/_form-group.scss */
 .govuk-form-group {
   margin-bottom: 20px;
@@ -1943,8 +1851,6 @@
   position: relative;
   width: 100%;
   margin-top: 0;
-  margin-right: 0;
-  margin-left: 0;
   margin-bottom: 22px;
   padding: 8px 10px 7px;
   border: 2px solid transparent;
@@ -1996,36 +1902,36 @@
   }
 }
 
-/* line 55, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 53, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button:link, .govuk-button:visited, .govuk-button:active, .govuk-button:hover {
   color: #ffffff;
   text-decoration: none;
 }
 
-/* line 64, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 62, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button::-moz-focus-inner {
   padding: 0;
   border: 0;
 }
 
-/* line 69, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 67, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button:hover {
   background-color: #005a30;
 }
 
-/* line 73, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 71, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button:active {
   top: 2px;
 }
 
-/* line 82, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 80, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button:focus {
   border-color: #ffdd00;
   outline: 3px solid transparent;
   box-shadow: inset 0 0 0 1px #ffdd00;
 }
 
-/* line 110, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 108, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button:focus:not(:active):not(:hover) {
   border-color: #ffdd00;
   color: #0b0c0c;
@@ -2033,7 +1939,7 @@
   box-shadow: 0 2px 0 #0b0c0c;
 }
 
-/* line 122, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 120, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button:before {
   content: "";
   display: block;
@@ -2045,19 +1951,19 @@
   background: transparent;
 }
 
-/* line 146, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 144, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button:active:before {
   top: -4px;
 }
 
-/* line 151, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 149, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--disabled,
 .govuk-button[disabled="disabled"],
 .govuk-button[disabled] {
   opacity: 0.5;
 }
 
-/* line 156, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 154, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--disabled:hover,
 .govuk-button[disabled="disabled"]:hover,
 .govuk-button[disabled]:hover {
@@ -2065,14 +1971,14 @@
   cursor: default;
 }
 
-/* line 161, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 159, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--disabled:focus,
 .govuk-button[disabled="disabled"]:focus,
 .govuk-button[disabled]:focus {
   outline: none;
 }
 
-/* line 165, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 163, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--disabled:active,
 .govuk-button[disabled="disabled"]:active,
 .govuk-button[disabled]:active {
@@ -2080,49 +1986,49 @@
   box-shadow: 0 2px 0 #002d18;
 }
 
-/* line 174, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 172, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--secondary {
   background-color: #f3f2f1;
   box-shadow: 0 2px 0 #929191;
 }
 
-/* line 178, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 176, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--secondary, .govuk-button--secondary:link, .govuk-button--secondary:visited, .govuk-button--secondary:active, .govuk-button--secondary:hover {
   color: #0b0c0c;
 }
 
-/* line 197, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 195, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--secondary:hover {
   background-color: #dbdad9;
 }
 
-/* line 200, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 198, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--secondary[disabled]:hover {
   background-color: #f3f2f1;
 }
 
-/* line 206, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 204, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--warning {
   background-color: #d4351c;
   box-shadow: 0 2px 0 #55150b;
 }
 
-/* line 210, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 208, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--warning, .govuk-button--warning:link, .govuk-button--warning:visited, .govuk-button--warning:active, .govuk-button--warning:hover {
   color: #ffffff;
 }
 
-/* line 229, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 227, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--warning:hover {
   background-color: #aa2a16;
 }
 
-/* line 232, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 230, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--warning[disabled]:hover {
   background-color: #d4351c;
 }
 
-/* line 238, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 236, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button--start {
   font-weight: 700;
   font-size: 18px;
@@ -2138,7 +2044,7 @@
 }
 
 @media (min-width: 40.0625em) {
-  /* line 238, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+  /* line 236, node_modules/govuk-frontend/govuk/components/button/_index.scss */
   .govuk-button--start {
     font-size: 24px;
     font-size: 1.5rem;
@@ -2147,14 +2053,14 @@
 }
 
 @media print {
-  /* line 238, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+  /* line 236, node_modules/govuk-frontend/govuk/components/button/_index.scss */
   .govuk-button--start {
     font-size: 18pt;
     line-height: 1;
   }
 }
 
-/* line 256, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+/* line 254, node_modules/govuk-frontend/govuk/components/button/_index.scss */
 .govuk-button__start-icon {
   margin-left: 5px;
   vertical-align: middle;
@@ -2165,7 +2071,7 @@
 }
 
 @media (min-width: 48.0625em) {
-  /* line 256, node_modules/govuk-frontend/govuk/components/button/_index.scss */
+  /* line 254, node_modules/govuk-frontend/govuk/components/button/_index.scss */
   .govuk-button__start-icon {
     margin-left: 10px;
   }
@@ -3007,93 +2913,13 @@ x:-moz-any-link {
 
 /* line 16, node_modules/govuk-frontend/govuk/components/character-count/_index.scss */
 .govuk-character-count__message {
-  font-family: "GDS Transport", arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  -webkit-font-feature-settings: "tnum" 1;
-  font-feature-settings: "tnum" 1;
-  font-weight: 400;
   margin-top: 0;
   margin-bottom: 0;
 }
 
-@media print {
-  /* line 16, node_modules/govuk-frontend/govuk/components/character-count/_index.scss */
-  .govuk-character-count__message {
-    font-family: sans-serif;
-  }
-}
-
-@supports (font-variant-numeric: tabular-nums) {
-  /* line 16, node_modules/govuk-frontend/govuk/components/character-count/_index.scss */
-  .govuk-character-count__message {
-    -webkit-font-feature-settings: normal;
-    font-feature-settings: normal;
-    font-variant-numeric: tabular-nums;
-  }
-}
-
-/* line 22, node_modules/govuk-frontend/govuk/components/character-count/_index.scss */
+/* line 21, node_modules/govuk-frontend/govuk/components/character-count/_index.scss */
 .govuk-character-count__message--disabled {
   visibility: hidden;
-}
-
-/* line 6, node_modules/govuk-frontend/govuk/components/cookie-banner/_index.scss */
-.govuk-cookie-banner {
-  font-family: "GDS Transport", arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 400;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
-  padding-top: 20px;
-  border-bottom: 10px solid transparent;
-  background-color: #f3f2f1;
-}
-
-@media print {
-  /* line 6, node_modules/govuk-frontend/govuk/components/cookie-banner/_index.scss */
-  .govuk-cookie-banner {
-    font-family: sans-serif;
-  }
-}
-
-@media (min-width: 40.0625em) {
-  /* line 6, node_modules/govuk-frontend/govuk/components/cookie-banner/_index.scss */
-  .govuk-cookie-banner {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
-  }
-}
-
-@media print {
-  /* line 6, node_modules/govuk-frontend/govuk/components/cookie-banner/_index.scss */
-  .govuk-cookie-banner {
-    font-size: 14pt;
-    line-height: 1.15;
-  }
-}
-
-/* line 22, node_modules/govuk-frontend/govuk/components/cookie-banner/_index.scss */
-.govuk-cookie-banner[hidden] {
-  display: none;
-}
-
-/* line 26, node_modules/govuk-frontend/govuk/components/cookie-banner/_index.scss */
-.govuk-cookie-banner__message {
-  margin-bottom: -10px;
-}
-
-/* line 30, node_modules/govuk-frontend/govuk/components/cookie-banner/_index.scss */
-.govuk-cookie-banner__message[hidden] {
-  display: none;
-}
-
-/* line 36, node_modules/govuk-frontend/govuk/components/cookie-banner/_index.scss */
-.govuk-cookie-banner__message:focus {
-  outline: none;
 }
 
 /* line 2, node_modules/govuk-frontend/govuk/components/summary-list/_index.scss */
@@ -6228,149 +6054,6 @@ x:-moz-any-link {
   font-weight: 700;
   display: table-caption;
   text-align: left;
-}
-
-/* line 53, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-.govuk-table__caption--xl {
-  font-family: "GDS Transport", arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 700;
-  font-size: 32px;
-  font-size: 2rem;
-  line-height: 1.09375;
-  margin-bottom: 15px;
-}
-
-@media print {
-  /* line 53, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--xl {
-    font-family: sans-serif;
-  }
-}
-
-@media (min-width: 40.0625em) {
-  /* line 53, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--xl {
-    font-size: 48px;
-    font-size: 3rem;
-    line-height: 1.0416666667;
-  }
-}
-
-@media print {
-  /* line 53, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--xl {
-    font-size: 32pt;
-    line-height: 1.15;
-  }
-}
-
-/* line 58, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-.govuk-table__caption--l {
-  font-family: "GDS Transport", arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 700;
-  font-size: 24px;
-  font-size: 1.5rem;
-  line-height: 1.0416666667;
-  margin-bottom: 15px;
-}
-
-@media print {
-  /* line 58, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--l {
-    font-family: sans-serif;
-  }
-}
-
-@media (min-width: 40.0625em) {
-  /* line 58, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--l {
-    font-size: 36px;
-    font-size: 2.25rem;
-    line-height: 1.1111111111;
-  }
-}
-
-@media print {
-  /* line 58, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--l {
-    font-size: 24pt;
-    line-height: 1.05;
-  }
-}
-
-/* line 63, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-.govuk-table__caption--m {
-  font-family: "GDS Transport", arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 700;
-  font-size: 18px;
-  font-size: 1.125rem;
-  line-height: 1.1111111111;
-  margin-bottom: 15px;
-}
-
-@media print {
-  /* line 63, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--m {
-    font-family: sans-serif;
-  }
-}
-
-@media (min-width: 40.0625em) {
-  /* line 63, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--m {
-    font-size: 24px;
-    font-size: 1.5rem;
-    line-height: 1.25;
-  }
-}
-
-@media print {
-  /* line 63, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--m {
-    font-size: 18pt;
-    line-height: 1.15;
-  }
-}
-
-/* line 68, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-.govuk-table__caption--s {
-  font-family: "GDS Transport", arial, sans-serif;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  font-weight: 700;
-  font-size: 16px;
-  font-size: 1rem;
-  line-height: 1.25;
-}
-
-@media print {
-  /* line 68, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--s {
-    font-family: sans-serif;
-  }
-}
-
-@media (min-width: 40.0625em) {
-  /* line 68, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--s {
-    font-size: 19px;
-    font-size: 1.1875rem;
-    line-height: 1.3157894737;
-  }
-}
-
-@media print {
-  /* line 68, node_modules/govuk-frontend/govuk/components/table/_index.scss */
-  .govuk-table__caption--s {
-    font-size: 14pt;
-    line-height: 1.15;
-  }
 }
 
 /* line 2, node_modules/govuk-frontend/govuk/components/warning-text/_index.scss */
@@ -11711,10 +11394,10 @@ Prism.languages.js = Prism.languages.javascript;
   <h2 class="govuk-heading-s">Accordion</h2>
   <section>
     <div id="abc123" class="govuk-accordion" data-module="govuk-accordion">
-    <div id="home-electronics-section" class="govuk-accordion__section">
+    <div id="home-electronics-section" class="govuk-accordion__section govuk-accordion__section--expanded">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-          <span id="home-electronics" class="govuk-accordion__section-button">Home electronics</span>
+          <span id="home-electronics" class="govuk-accordion__section-button" aria-expanded="true">Home electronics</span>
         </h2>
           <div id="home-electronics-summary" class="govuk-accordion__section-summary govuk-body">Entertainment, communication and recreation</div>
       </div>
@@ -11722,7 +11405,7 @@ Prism.languages.js = Prism.languages.javascript;
 </div>    <div id="appliances-section" class="govuk-accordion__section">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-          <span id="appliances" class="govuk-accordion__section-button">Appliances</span>
+          <span id="appliances" class="govuk-accordion__section-button" aria-expanded="false">Appliances</span>
         </h2>
           <div id="appliances-summary" class="govuk-accordion__section-summary govuk-body">Laundry, cookers and vacuum cleaners</div>
       </div>
@@ -11730,7 +11413,7 @@ Prism.languages.js = Prism.languages.javascript;
 </div>    <div id="toys-section" class="govuk-accordion__section">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-          <span id="toys" class="govuk-accordion__section-button">Toys</span>
+          <span id="toys" class="govuk-accordion__section-button" aria-expanded="false">Toys</span>
         </h2>
       </div>
       <div id="toys-content" class="govuk-accordion__section-content" aria-labelledby="toys">
@@ -11744,7 +11427,8 @@ Prism.languages.js = Prism.languages.javascript;
     <pre><code class="language-ruby">render GovukComponent::Accordion.new(id: 'abc123') do |component|
   component.slot(:section,
     title: 'Home electronics',
-    summary: 'Entertainment, communication and recreation') do
+    summary: 'Entertainment, communication and recreation',
+    expanded: true) do
       tag.p(class: 'govuk-body') do
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       end
@@ -11781,21 +11465,21 @@ end
     <div id="section-1-section" class="govuk-accordion__section">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-          <span id="section-1" class="govuk-accordion__section-button">Section 1</span>
+          <span id="section-1" class="govuk-accordion__section-button" aria-expanded="false">Section 1</span>
         </h2>
       </div>
       <div id="section-1-content" class="govuk-accordion__section-content" aria-labelledby="section-1"><p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></div>
-</div>    <div id="section-2-section" class="govuk-accordion__section">
+</div>    <div id="section-2-section" class="govuk-accordion__section govuk-accordion__section--expanded">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-          <span id="section-2" class="govuk-accordion__section-button">Section 2</span>
+          <span id="section-2" class="govuk-accordion__section-button" aria-expanded="true">Section 2</span>
         </h2>
       </div>
       <div id="section-2-content" class="govuk-accordion__section-content" aria-labelledby="section-2"><p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></div>
 </div>    <div id="section-3-section" class="govuk-accordion__section">
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-          <span id="section-3" class="govuk-accordion__section-button">Section 3</span>
+          <span id="section-3" class="govuk-accordion__section-button" aria-expanded="false">Section 3</span>
         </h2>
       </div>
       <div id="section-3-content" class="govuk-accordion__section-content" aria-labelledby="section-3"><p class="govuk-body">Lorem ipsum dolor sit amet, consectetur adipiscing elit.</p></div>
@@ -11809,7 +11493,7 @@ end
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     end
   end
-  accordion.add_section(title: 'Section 2') do
+  accordion.add_section(title: 'Section 2', expanded: true) do
     tag.p(class: 'govuk-body') do
       "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
     end
@@ -11964,27 +11648,27 @@ end
 <article class="example govuk-!-margin-top-9" id="cookie-banner">
   <h2 class="govuk-heading-s">Cookie banner</h2>
   <section>
-    <div class="govuk-cookie-banner">
+    <div class="govuk-cookie-banner" role="region" aria-label="Cookie banner">
   <div class="govuk-cookie-banner__message govuk-width-container">
     <div class="govuk-grid-row">
       <div class="govuk-grid-column-two-thirds">
-        <h2 class="govuk-cookie-banner__heading govuk-heading-m">
-          Cookies on a service
-        </h2>
+          <h2 class="govuk-cookie-banner__heading govuk-heading-m">
+            Cookies on a service
+          </h2>
 
         <div class="govuk-cookie-banner__content">
           <p class="govuk-body">A paragraph.</p>
-<p class="govuk-body-s">A second smaller paragraph.</p>
+<p class="govuk-body-s">A second, smaller paragraph.</p>
         </div>
       </div>
     </div>
 
     <div class="govuk-button-group">
       <form class="button_to" method="post" action="#accept">
-<input class="govuk-button" type="submit" value="Accept cookies"><input type="hidden" name="authenticity_token" value="t+ABJ+rztwK0g+usl86yYWTZWXBHpbLgXnKFMd8ZwPISbN7TlfdqDpFWTT0XEmvkTBvFJrh/vXuWwji7ZxPIJQ==">
+<input class="govuk-button" type="submit" value="Accept cookies"><input type="hidden" name="authenticity_token" value="CKjvcm5XqxTbQVwAFOibImAnm2fMS9Z/qtH/tHMzbBwKEY5R9W94YX5AwxeZ28SZJGWW4ag5gK9yrC38J20tRQ==">
 </form>
 <form class="button_to" method="post" action="#reject">
-<input class="govuk-button" type="submit" value="Reject cookies"><input type="hidden" name="authenticity_token" value="WxYDihHQ1LLg2WzQ9ksna6QgrEu2rB/ClwZWDobubsv+mtx+btQJvsUMykF2l/7ujOIwHUl2EFlftuuEPuRmHA==">
+<input class="govuk-button" type="submit" value="Reject cookies"><input type="hidden" name="authenticity_token" value="7AQWnal+m1Jb+JrDUDq54o6DDDdPS/2x3JsD7uJtPgnuvXe+MkZIJ/75BdTdCeZZysEBsSs5q2EE5tGmtjN/UA==">
 </form>
 <a class="govuk-link" href="#view">View cookies</a>
     </div>
@@ -11992,11 +11676,11 @@ end
 </div>
   </section>
   <section>
-    <pre><code class="language-ruby">render GovukComponent::CookieBanner.new(title: 'Cookies on a service') do |component|
+    <pre><code class="language-ruby">render GovukComponent::CookieBanner.new(title: "Cookies on a service") do |component|
   component.with(:body) do
     safe_join([
       tag.p("A paragraph.", class: "govuk-body"),
-      tag.p("A second smaller paragraph.", class: "govuk-body-s"),
+      tag.p("A second, smaller paragraph.", class: "govuk-body-s"),
     ])
   end
   component.with(:actions) do
@@ -12351,7 +12035,7 @@ end
   <h2 class="govuk-heading-s">Button links (this will render a form that POSTs)</h2>
   <section>
     <form class="button_to" method="post" action="/">
-<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="gx/bn3yShVvku3Mt6aAPrCuSNhHGt1kb3teb9Nx390gmkwRrA5ZYV8Fu1bxpfNYpA1CqRzltVoAWZyZ+ZH3/nw==">
+<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="Qjxo4uRrD107rr9n3YXCDKDowzyiGPSjZ8A5Im8wD2pAhQnBf1PcKJ6vIHBQtp235KrOusZqonO/vetqO25OMw==">
 </form>
   </section>
   <section>

--- a/spec/components/govuk_component/accordion_spec.rb
+++ b/spec/components/govuk_component/accordion_spec.rb
@@ -88,6 +88,18 @@ RSpec.describe(GovukComponent::Accordion, type: :component) do
 
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'
+
+    it 'sections should have correct expanded state' do
+      render_inline(GovukComponent::Accordion.new) do |component|
+        component.slot(:section, expanded: true, title: 'section 1', html_attributes: { id: 'section_1' }) { 'abc' }
+        component.slot(:section, title: 'section 2', html_attributes: { id: 'section_2' }) { 'def' }
+      end
+      expect(page).to have_css('#section_1.govuk-accordion__section.govuk-accordion__section--expanded')
+      expect(page).to have_css('#section_2.govuk-accordion__section')
+      expect(page).not_to have_css('#section_2.govuk-accordion__section.govuk-accordion__section--expanded')
+      expect(page).to have_css('span#section-1[aria-expanded="true"]')
+      expect(page).to have_css('span#section-2[aria-expanded="false"]')
+    end
   end
 
   it_behaves_like 'a component with a DSL wrapper' do

--- a/spec/dummy/app/views/demos/examples/_accordion.html.erb
+++ b/spec/dummy/app/views/demos/examples/_accordion.html.erb
@@ -4,7 +4,8 @@
   render GovukComponent::Accordion.new(id: 'abc123') do |component|
     component.slot(:section,
       title: 'Home electronics',
-      summary: 'Entertainment, communication and recreation') do
+      summary: 'Entertainment, communication and recreation',
+      expanded: true) do
         tag.p(class: 'govuk-body') do
           "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         end
@@ -39,7 +40,7 @@
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       end
     end
-    accordion.add_section(title: 'Section 2') do
+    accordion.add_section(title: 'Section 2', expanded: true) do
       tag.p(class: 'govuk-body') do
         "Lorem ipsum dolor sit amet, consectetur adipiscing elit."
       end


### PR DESCRIPTION
I wanted to use the Accordion component to replace some long-hand markup in Find Teacher Training (https://github.com/DFE-Digital/find-teacher-training/blob/13f583cb053a5a7687465fccbb66200261b955f4/app/views/result_filters/subject/_form.html.erb#L10) and found that there was no way to specify an initially expanded section (slot). This PR is an attempt to add the option to the Accordion component's Slot sub-component.

I don't think this can be done simply by adding CSS class due the `aria` attribute needed on the heading so I've added an explicit `expanded` option here. There may be a simpler way!

One source of confusion (for me) was some JavaScript included in the design system that persists the expanded state of accordions in local storage. So if you've already viewed a page, toggled the expanded state and then revisit it whatever is in local storage overrides whatever the markup specifies.