### PR TITLE
Make render? check for content as well as headings

### DIFF
--- a/app/components/govuk_component/notification_banner.rb
+++ b/app/components/govuk_component/notification_banner.rb
@@ -24,7 +24,7 @@ class GovukComponent::NotificationBanner < GovukComponent::Base
   end
 
   def render?
-    headings.any?
+    headings.any? || content.present?
   end
 
   def title_tag

--- a/spec/components/govuk_component/notification_banner_spec.rb
+++ b/spec/components/govuk_component/notification_banner_spec.rb
@@ -15,7 +15,7 @@ RSpec.describe(GovukComponent::NotificationBanner, type: :component) do
 
   let(:kwargs) { { title: title } }
 
-  describe "rendering a notification banner" do
+  describe "rendering a notification banner with headings" do
     before do
       render_inline(GovukComponent::NotificationBanner.new(**kwargs)) do |nb|
         nb.slot(:heading, text: "omg")
@@ -194,6 +194,21 @@ RSpec.describe(GovukComponent::NotificationBanner, type: :component) do
       let(:expected_css) { '.govuk-notification-banner' }
 
       let(:block) { ->(banner) { banner.add_heading(text: "What a nice heading!") } }
+    end
+  end
+
+  describe "rendering a notification banner with arbitrary content" do
+    before do
+      render_inline(GovukComponent::NotificationBanner.new(**kwargs)) { additional_content }
+    end
+
+    let(:subject) { page }
+
+    specify "the extra banner with extra content is rendered" do
+      expect(subject).to have_css(".govuk-notification-banner > .govuk-notification-banner__content") do |content|
+        expect(content).to have_css("p", text: "The quick brown fox")
+        expect(content).to have_css("blockquote", text: "Jumped over the lazy dog")
+      end
     end
   end
 end


### PR DESCRIPTION
This allows the notification banner to be used in a more-flexible manner but still prevents an empty one from being rendered.

Fixes #119

cc @asmega @fofr 