### PR TITLE
Add some additional breadcrumb arguments

### DIFF
--- a/app/components/govuk_component/breadcrumbs.rb
+++ b/app/components/govuk_component/breadcrumbs.rb
@@ -1,15 +1,20 @@
 class GovukComponent::Breadcrumbs < GovukComponent::Base
   attr_accessor :breadcrumbs
 
-  def initialize(breadcrumbs:, classes: [], html_attributes: {})
+  def initialize(breadcrumbs:, hide_in_print: false, collapse_on_mobile: false, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @breadcrumbs = breadcrumbs
+    @breadcrumbs        = breadcrumbs
+    @hide_in_print      = hide_in_print
+    @collapse_on_mobile = collapse_on_mobile
   end
 
 private
 
   def default_classes
-    %w(govuk-breadcrumbs)
+    %w(govuk-breadcrumbs).tap do |classes|
+      classes << "govuk-!-display-none-print" if @hide_in_print
+      classes << "govuk-breadcrumbs--collapse-on-mobile" if @collapse_on_mobile
+    end
   end
 end

--- a/spec/components/govuk_component/breadcrumbs_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_spec.rb
@@ -29,6 +29,18 @@ RSpec.describe(GovukComponent::Breadcrumbs, type: :component) do
     end
   end
 
+  describe "hiding breadcrumbs when printing" do
+    let(:kwargs) { { breadcrumbs: breadcrumbs, hide_in_print: true } }
+
+    specify { expect(page).to have_css('div.govuk-breadcrumbs.govuk-\!-display-none-print') }
+  end
+
+  describe "making breadcrumbs collapse on mobile" do
+    let(:kwargs) { { breadcrumbs: breadcrumbs, collapse_on_mobile: true } }
+
+    specify { expect(page).to have_css('div.govuk-breadcrumbs.govuk-breadcrumbs--collapse-on-mobile') }
+  end
+
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
 end


### PR DESCRIPTION
* `collapse_on_mobile` - make the breadcrumbs automatically adjust their display based on screen size
* `hide_in_print` - suppress the breadcrumbs when printing the page

Fixes #125, #126