### PR TITLE
Resolve `with_content_areas` view_component deprecation warning

### DIFF
--- a/app/components/govuk_component/cookie_banner.rb
+++ b/app/components/govuk_component/cookie_banner.rb
@@ -1,5 +1,6 @@
 class GovukComponent::CookieBanner < GovukComponent::Base
-  with_content_areas :body, :actions
+  renders_one :body
+  renders_one :actions
 
   attr_accessor :title, :aria_label
 

--- a/spec/components/govuk_component/cookie_banner_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_spec.rb
@@ -25,20 +25,24 @@ RSpec.describe(GovukComponent::CookieBanner, type: :component) do
 
   subject! do
     render_inline(described_class.new(**kwargs)) do |component|
-      component.with(:body) { body }
-      component.with(:actions) { actions }
+      component.body { body }
+      component.actions { actions }
     end
   end
 
   specify "contains a cookies banner with the correct title, body text and actions" do
-    expect(page).to have_css("div", class: %w(govuk-cookie-banner)) do |banner|
-      expect(banner).to have_css("h2", class: %w(govuk-cookie-banner__heading), text: title)
-      within "div.govuk-cookie-banner__content" do
-        expect(banner).to have_content(body)
-      end
-      within "div.govuk-button-group" do
-        expect(banner).to have_content(actions)
-      end
+    expect(page).to have_css("h2", class: %w(govuk-cookie-banner__heading), text: title)
+
+    expect(page).to have_css('.govuk-cookie-banner__content') do |body|
+      expect(body).to have_content('An introductory paragraph.')
+      expect(body).to have_content('A second paragraph.')
+    end
+
+    expect(page).to have_css('.govuk-button-group') do |actions|
+      expect(actions).to have_button(value: 'Accept')
+      expect(actions).to have_button(value: 'Reject')
+
+      expect(actions).to have_link(text: 'View', href: '/view-path')
     end
   end
 


### PR DESCRIPTION
> DEPRECATION WARNING: `with_content_areas` is deprecated and will be removed in ViewComponent v3.0.0.
Use slots (https://viewcomponent.org/guide/slots.html) instead. (called from <top (required)> at .../apply-for-teacher-training/config/environment.rb:8)

This PR also fixes a non working spec, as testing components using a `within` block does not appear to be supported and results in a false positive.