### PR TITLE
Fix header component

### DIFF
--- a/app/components/govuk_component/header.html.erb
+++ b/app/components/govuk_component/header.html.erb
@@ -32,7 +32,7 @@
       <% if items.any? %>
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu"><%= menu_button_label %></button>
         <nav>
-          <%= tag.ul(class: navigation_classes, aria: { label: "Top Level Navigation" }) do %>
+          <%= tag.ul(class: navigation_classes, id: "navigation", aria: { label: "Top Level Navigation" }) do %>
             <% items.each do |item| %>
               <%= tag.li(class: item.classes.append(item.active_class), **item.html_attributes) do %>
                 <% if item.link? %>

--- a/app/components/govuk_component/header.html.erb
+++ b/app/components/govuk_component/header.html.erb
@@ -32,7 +32,7 @@
       <% if items.any? %>
         <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu"><%= menu_button_label %></button>
         <nav>
-          <%= tag.ul(class: navigation_classes, id: "navigation", aria: { label: "Top Level Navigation" }) do %>
+          <%= tag.ul(class: navigation_classes, id: "navigation", aria: { label: navigation_label }) do %>
             <% items.each do |item| %>
               <%= tag.li(class: item.classes.append(item.active_class), **item.html_attributes) do %>
                 <% if item.link? %>

--- a/app/components/govuk_component/header.html.erb
+++ b/app/components/govuk_component/header.html.erb
@@ -30,7 +30,7 @@
       <% end %>
 
       <% if items.any? %>
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu"><%= menu_button_label %></button>
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="<%= menu_button_label %>">Menu</button>
         <nav>
           <%= tag.ul(class: navigation_classes, id: "navigation", aria: { label: navigation_label }) do %>
             <% items.each do |item| %>

--- a/app/components/govuk_component/header.html.erb
+++ b/app/components/govuk_component/header.html.erb
@@ -30,9 +30,7 @@
       <% end %>
 
       <% if items.any? %>
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu">
-          <%= menu_button_label %>
-        </button>
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu"><%= menu_button_label %></button>
         <nav>
           <%= tag.ul(class: navigation_classes, aria: { label: "Top Level Navigation" }) do %>
             <% items.each do |item| %>

--- a/app/components/govuk_component/header.rb
+++ b/app/components/govuk_component/header.rb
@@ -1,7 +1,7 @@
 class GovukComponent::Header < GovukComponent::Base
   include ViewComponent::Slotable
 
-  attr_accessor :logo, :logo_href, :service_name, :service_name_href, :product_name, :menu_button_label
+  attr_accessor :logo, :logo_href, :service_name, :service_name_href, :product_name, :menu_button_label, :navigation_label
 
   with_slot :item, collection: true, class_name: 'Item'
   wrap_slot :item
@@ -9,7 +9,7 @@ class GovukComponent::Header < GovukComponent::Base
   with_slot :product_description
   wrap_slot :product_description
 
-  def initialize(logo: 'GOV.UK', logo_href: '/', service_name: nil, service_name_href: '/', product_name: nil, menu_button_label: 'Menu', classes: [], navigation_classes: [], html_attributes: {})
+  def initialize(logo: 'GOV.UK', logo_href: '/', service_name: nil, service_name_href: '/', product_name: nil, menu_button_label: 'Menu', classes: [], navigation_classes: [], navigation_label: 'Navigation menu', html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @logo               = logo
@@ -19,6 +19,7 @@ class GovukComponent::Header < GovukComponent::Base
     @product_name       = product_name
     @menu_button_label  = menu_button_label
     @navigation_classes = navigation_classes
+    @navigation_label   = navigation_label
   end
 
 private

--- a/app/components/govuk_component/header.rb
+++ b/app/components/govuk_component/header.rb
@@ -9,7 +9,7 @@ class GovukComponent::Header < GovukComponent::Base
   with_slot :product_description
   wrap_slot :product_description
 
-  def initialize(logo: 'GOV.UK', logo_href: '/', service_name: nil, service_name_href: '/', product_name: nil, menu_button_label: 'Menu', classes: [], navigation_classes: [], navigation_label: 'Navigation menu', html_attributes: {})
+  def initialize(logo: 'GOV.UK', logo_href: '/', service_name: nil, service_name_href: '/', product_name: nil, menu_button_label: 'Show or hide navigation menu', classes: [], navigation_classes: [], navigation_label: 'Navigation menu', html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @logo               = logo

--- a/docs/index.html
+++ b/docs/index.html
@@ -11479,7 +11479,7 @@ end
   <h2 class="govuk-heading-s">Button links (this will render a form that POSTs)</h2>
   <section>
     <form class="button_to" method="post" action="/">
-<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="heQSZ9g9ov74GiyNRnB1pmXH6Dq0zWFaA7YeQOX6NC3Uj1WHYxA7g5OCrkzbxj9W1xpVYhplSSxNGOG9xfrLAg==">
+<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="DinppWpB4VzEUVzCDpkvG+WVDaPU6XfNC2bheqWeQhVid8lJhFuvI+ztxgCnu4pTRMnfAeWAuUgLZ8bcoj0eMw==">
 </form>
   </section>
   <section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11400,11 +11400,9 @@ end
     </div>
     <div class="govuk-header__content">
 
-        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu">
-          Menu
-        </button>
+        <button type="button" class="govuk-header__menu-button govuk-js-header-toggle" aria-controls="navigation" aria-label="Show or hide navigation menu">Menu</button>
         <nav>
-          <ul class="govuk-header__navigation" aria-label="Top Level Navigation">
+          <ul class="govuk-header__navigation" id="navigation" aria-label="Navigation menu">
               <li class="govuk-header__navigation-item">
                   <a class="govuk-header__link" href="/#page-a">Page A</a>
 </li>              <li class="govuk-header__navigation-item">
@@ -11481,7 +11479,7 @@ end
   <h2 class="govuk-heading-s">Button links (this will render a form that POSTs)</h2>
   <section>
     <form class="button_to" method="post" action="/">
-<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="SkbREYgXhlkTsFBvzFBNmryjTerr8tpurNPWsCgdll+4Czfs8jCWNmRBUQ7+QrUnVMsyGCl03UHn3vqajQS08Q==">
+<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="NIR20t4NpjLqMIjK0PJ00Pg6Oq8MioSZK7xJnLjqbSujZ+v/fAA7h1TWv8VngsGc65I7Z1uuWBmBpyXihwxROQ==">
 </form>
   </section>
   <section>

--- a/docs/index.html
+++ b/docs/index.html
@@ -11479,7 +11479,7 @@ end
   <h2 class="govuk-heading-s">Button links (this will render a form that POSTs)</h2>
   <section>
     <form class="button_to" method="post" action="/">
-<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="NIR20t4NpjLqMIjK0PJ00Pg6Oq8MioSZK7xJnLjqbSujZ+v/fAA7h1TWv8VngsGc65I7Z1uuWBmBpyXihwxROQ==">
+<input class="govuk-button" type="submit" value="Home"><input type="hidden" name="authenticity_token" value="heQSZ9g9ov74GiyNRnB1pmXH6Dq0zWFaA7YeQOX6NC3Uj1WHYxA7g5OCrkzbxj9W1xpVYhplSSxNGOG9xfrLAg==">
 </form>
   </section>
   <section>

--- a/spec/components/govuk_component/header_spec.rb
+++ b/spec/components/govuk_component/header_spec.rb
@@ -114,6 +114,20 @@ RSpec.describe(GovukComponent::Header, type: :component) do
         end
       end
 
+      context 'when the navigation label is overriden' do
+        let(:custom_label) { 'Top level navigation' }
+
+        subject! do
+          render_inline(GovukComponent::Header.new(**kwargs.merge(navigation_label: custom_label))) do |component|
+            items.each { |item| component.slot(:item, **item) }
+          end
+        end
+
+        specify 'the navigation label contains the custom text' do
+          expect(page).to have_css(%(.govuk-header__navigation[aria-label='#{custom_label}']))
+        end
+      end
+
       specify 'the navigation block should be present in the output' do
         expect(page).to have_css('nav')
       end

--- a/spec/components/govuk_component/header_spec.rb
+++ b/spec/components/govuk_component/header_spec.rb
@@ -109,8 +109,8 @@ RSpec.describe(GovukComponent::Header, type: :component) do
           end
         end
 
-        specify 'the button contains the custom text' do
-          expect(page).to have_css('.govuk-header__content button.govuk-header__menu-button', text: custom_label)
+        specify 'the button label contains the custom text' do
+          expect(page).to have_css(%(.govuk-header__menu-button[aria-label='#{custom_label}']))
         end
       end
 


### PR DESCRIPTION
There are still some outstanding issues with the header component, which this PR attempts to address.

* Fixes trailing whitespace around the  ‘Menu’ text. This space is most noticeable when hovering over the button when this space is underlined
* Fixes the menu button not showing or hiding the navigation menu
* Add a new `navigation_label` param. This matches the `navigationLabel` setting available in the design system component: 

  > Text for the `aria-label` attribute of the navigation. Defaults to "Navigation menu".

* Changes how `menu_button_label` is applied, to match the corresponding `menuButtonLabel` setting used by the design system component (**breaking change**):
 
  > Text for the `aria-label` attribute of the button that toggles the navigation. Defaults to "Show or hide navigation menu".

* * *

I’ve tied to update the corresponding tests, but there was no documentation on how to run tests on this project. I tried `cd spec/dummy` and running `bin/rake spec`, but not sure this was right.