### PR TITLE
Add aria-controls to accordion button so that govuk-frontend JS works

### DIFF
--- a/app/components/govuk_component/accordion.html.erb
+++ b/app/components/govuk_component/accordion.html.erb
@@ -3,7 +3,7 @@
     <%= tag.div(id: section.id(suffix: 'section'), class: section.classes, **section.html_attributes) do %>
       <div class="govuk-accordion__section-header">
         <h2 class="govuk-accordion__section-heading">
-          <%= tag.span(section.title, id: section.id, class: "govuk-accordion__section-button", aria: { expanded: section.expanded? }) %>
+          <%= tag.span(section.title, id: section.id, class: "govuk-accordion__section-button", aria: { expanded: section.expanded?, controls: section.id(suffix: 'content') }) %>
         </h2>
         <% if section.summary.present? %>
           <%= tag.div(section.summary, id: section.id(suffix: 'summary'), class: %w(govuk-accordion__section-summary govuk-body)) %>

--- a/spec/components/govuk_component/accordion_spec.rb
+++ b/spec/components/govuk_component/accordion_spec.rb
@@ -56,6 +56,15 @@ RSpec.describe(GovukComponent::Accordion, type: :component) do
     end
   end
 
+  specify 'the section ids should match button aria-controls' do
+    sections.each do |title, _|
+      id = title.parameterize
+
+      expect(page).to have_css('#' + id)
+      expect(page).to have_css(%(span[aria-controls='#{id}-content']))
+    end
+  end
+
   describe 'summaries' do
     context 'when no summary is present' do
       specify 'no summary should be present' do


### PR DESCRIPTION
## The problem
Accordion state was being incorrectly remembered (it would apply the remembered state to all accordion elements with that index on the page)

## The solution
- Noticed a discrepancy between the design system implementation and the view component (missing aria-controls attribute)
- Added `aria-controls` attribute to the accordion button
- It now works as intended 🎉 