### PR TITLE
Upgrade the component helper and decomission the v2 rspec tag

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,1 @@
 --require spec_helper
---tag "@version:2"

--- a/app/helpers/govuk_components_helper.rb
+++ b/app/helpers/govuk_components_helper.rb
@@ -10,7 +10,7 @@ module GovukComponentsHelper
     govuk_inset_text: 'GovukComponent::InsetTextComponent',
     govuk_notification_banner: 'GovukComponent::NotificationBannerComponent',
     govuk_panel: 'GovukComponent::PanelComponent',
-    govuk_phase_banner: 'GovukComponent::PhaseBanner',
+    govuk_phase_banner: 'GovukComponent::PhaseBannerComponent',
     govuk_start_now_button: 'GovukComponent::StartButtonComponent',
     govuk_summary_list: 'GovukComponent::SummaryListComponent',
     govuk_tabs: 'GovukComponent::TabComponent',

--- a/spec/components/govuk_component/accordion_component_spec.rb
+++ b/spec/components/govuk_component/accordion_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::AccordionComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::AccordionComponent, type: :component) do
   include_context 'helpers'
   include_context 'setup'
 

--- a/spec/components/govuk_component/back_link_component_spec.rb
+++ b/spec/components/govuk_component/back_link_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::BackLinkComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
   include_context 'setup'
 
   let(:text) { 'Department for Education' }

--- a/spec/components/govuk_component/breadcrumbs_component_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
   include_context 'setup'
 
   let(:breadcrumbs) do

--- a/spec/components/govuk_component/cookie_banner_component_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_component_spec.rb
@@ -1,6 +1,6 @@
 require "spec_helper"
 
-RSpec.describe(GovukComponent::CookieBannerComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::CookieBannerComponent, type: :component) do
   include_context 'setup'
   include_context 'helpers'
 

--- a/spec/components/govuk_component/details_component_spec.rb
+++ b/spec/components/govuk_component/details_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::DetailsComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::DetailsComponent, type: :component) do
   include_context 'helpers'
   include_context 'setup'
 

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::FooterComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   include_context 'setup'
   include_context 'helpers'
 

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::HeaderComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
   include_context "setup"
   include_context "helpers"
 

--- a/spec/components/govuk_component/inset_text_component_spec.rb
+++ b/spec/components/govuk_component/inset_text_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::InsetTextComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::InsetTextComponent, type: :component) do
   include_context 'helpers'
   include_context 'setup'
 

--- a/spec/components/govuk_component/notification_banner_component_spec.rb
+++ b/spec/components/govuk_component/notification_banner_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
   include_context 'helpers'
   include_context 'setup'
 

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::PanelComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::PanelComponent, type: :component) do
   include_context 'helpers'
   include_context 'setup'
 

--- a/spec/components/govuk_component/phase_banner_component_spec.rb
+++ b/spec/components/govuk_component/phase_banner_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component) do
   include_context 'setup'
 
   let(:component_css_class) { "govuk-phase-banner" }

--- a/spec/components/govuk_component/start_button_component_spec.rb
+++ b/spec/components/govuk_component/start_button_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::StartButtonComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::StartButtonComponent, type: :component) do
   include_context 'setup'
 
   let(:component_css_class) { 'govuk-button--start' }

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::SummaryListComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
   include_context 'helpers'
   include_context 'setup'
 

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::TabComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::TabComponent, type: :component) do
   include_context 'setup'
   include_context 'helpers'
 

--- a/spec/components/govuk_component/tag_component_spec.rb
+++ b/spec/components/govuk_component/tag_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::TagComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::TagComponent, type: :component) do
   include_context 'setup'
 
   let(:text) { 'Alert' }

--- a/spec/components/govuk_component/warning_text_component_spec.rb
+++ b/spec/components/govuk_component/warning_text_component_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe(GovukComponent::WarningTextComponent, type: :component, version: 2) do
+RSpec.describe(GovukComponent::WarningTextComponent, type: :component) do
   include_context 'setup'
 
   let(:component_css_class) { 'govuk-warning-text' }

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -13,7 +13,7 @@ class HelperComponentMapping
   end
 end
 
-RSpec.describe(GovukComponentsHelper, type: 'helper', version: 1) do
+RSpec.describe(GovukComponentsHelper, type: 'helper', version: 2) do
   include_context 'helpers'
 
   [
@@ -42,7 +42,7 @@ RSpec.describe(GovukComponentsHelper, type: 'helper', version: 1) do
       helper_method: :govuk_details,
       klass: GovukComponent::DetailsComponent,
       args: [],
-      kwargs: { summary: 'Summary' },
+      kwargs: { summary_text: 'Summary' },
       css_matcher: %(.govuk-details)
     },
     {
@@ -79,7 +79,7 @@ RSpec.describe(GovukComponentsHelper, type: 'helper', version: 1) do
       args: [],
       kwargs: { title: 'Notification banner' },
       css_matcher: %(.govuk-notification-banner),
-      block: Proc.new { |nb| nb.add_heading(text: "heading 1", link_text: "link 1", link_href: "/link-1") },
+      block: Proc.new { |nb| nb.heading(text: "heading 1", link_text: "link 1", link_href: "/link-1") },
     },
     {
       helper_method: :govuk_panel,
@@ -137,6 +137,7 @@ RSpec.describe(GovukComponentsHelper, type: 'helper', version: 1) do
         subject do
           Capybara::Node::Simple.new(helper.send(hcm.helper_method, *hcm.args, **hcm.kwargs, &hcm.block))
         end
+
         specify %(should render the component #{hcm.klass}) do
           expect(subject).to have_css(hcm.css_matcher)
         end

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -13,7 +13,7 @@ class HelperComponentMapping
   end
 end
 
-RSpec.describe(GovukComponentsHelper, type: 'helper', version: 2) do
+RSpec.describe(GovukComponentsHelper, type: 'helper') do
   include_context 'helpers'
 
   [


### PR DESCRIPTION
The component helper provides a 'wrapper' that makes usage easier. Each component gets a helper method, so instead of having to call `render GovukComponent::HeaderComponent.new(...)` you can call `govuk_header(...)`.

Now all the components have been through the first round of updating and polishing the tag to target migrated components can be removed too.
