### PR TITLE
Stop using instance variables in header template

### DIFF
--- a/app/components/govuk_component/header_component.html.erb
+++ b/app/components/govuk_component/header_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.header(class: classes, role: 'banner', data: { module: 'govuk-header' }, **html_attributes) do %>
   <%= tag.div(class: container_classes) do %>
     <div class="govuk-header__logo">
-      <%= link_to(@homepage_url, class: %w(govuk-header__link govuk-header__link--homepage)) do %>
+      <%= link_to(homepage_url, class: %w(govuk-header__link govuk-header__link--homepage)) do %>
         <span class="govuk-header__logotype">
           <% if custom_logo.present? %>
             <%= custom_logo %>
@@ -21,10 +21,10 @@
       <% end %>
     </div>
 
-    <% if @service_name.present? || @items.present? %>
+    <% if service_name.present? || items.present? %>
       <div class="govuk-header__content">
-        <% if @service_name.present? %>
-          <%= link_to(@service_name, @service_url, class: %w(govuk-header__link govuk-header__link--service-name)) %>
+        <% if service_name.present? %>
+          <%= link_to(service_name, service_url, class: %w(govuk-header__link govuk-header__link--service-name)) %>
         <% end %>
 
         <% if items.any? %>


### PR DESCRIPTION
This is no longer necessary and leads to confusion between what's set up in initialisation and what's provided by slots
