### PR TITLE
Allow summary text to be overriden with HTML

### DIFF
--- a/app/components/govuk_component/details_component.rb
+++ b/app/components/govuk_component/details_component.rb
@@ -1,6 +1,8 @@
 class GovukComponent::DetailsComponent < GovukComponent::Base
   attr_accessor :summary_text, :text
 
+  renders_one :summary_html
+
   def initialize(summary_text:, text: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
@@ -18,8 +20,12 @@ private
 
   def summary
     tag.summary(class: "govuk-details__summary") do
-      tag.span(summary_text, class: "govuk-details__summary-text")
+      tag.span(summary_content, class: "govuk-details__summary-text")
     end
+  end
+
+  def summary_content
+    summary_html || summary_text
   end
 
   def description

--- a/spec/components/govuk_component/details_component_spec.rb
+++ b/spec/components/govuk_component/details_component_spec.rb
@@ -26,6 +26,24 @@ RSpec.describe(GovukComponent::DetailsComponent, type: :component) do
     end
   end
 
+  context 'providing summary HTML' do
+    let(:summary_tag) { "em" }
+    let(:summary_text) { "Fancy summary" }
+    let(:summary_html) { helper.content_tag(summary_tag, summary_text) }
+
+    before do
+      render_inline(described_class.new(**kwargs)) do |component|
+        component.summary_html { summary_html }
+      end
+    end
+
+    specify 'renders the HTML correctly' do
+      expect(rendered_component).to have_tag("span", with: { class: "govuk-details__summary-text" }) do
+        with_tag(summary_tag, text: summary_text)
+      end
+    end
+  end
+
   context 'when a block is supplied' do
     before do
       render_inline(described_class.new(**kwargs.except(:text))) do


### PR DESCRIPTION
Text can be provided using the summary_text argument, HTML via the summary_html slot. If both are provided HTML takes precedence.
