### PR TITLE
Allow nil actions in the summary list

### DIFF
--- a/app/components/govuk_component/summary_list_component.rb
+++ b/app/components/govuk_component/summary_list_component.rb
@@ -35,11 +35,14 @@ private
 
       @key                  = key
       @value                = value
-      @href                 = action[:href]
-      @text                 = action[:text] || "Change"
-      @visually_hidden_text = " #{action[:visually_hidden_text] || key.downcase}"
-      @action_classes       = action[:classes] || []
-      @action_attributes    = action[:html_attributes] || {}
+
+      if action.present?
+        @href                 = action[:href]
+        @text                 = action[:text] || "Change"
+        @visually_hidden_text = " #{action[:visually_hidden_text] || key.downcase}"
+        @action_classes       = action[:classes] || []
+        @action_attributes    = action[:html_attributes] || {}
+      end
     end
 
     def action

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -123,4 +123,24 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
       expect(rendered_component).not_to have_tag('dd', with: { class: 'govuk-summary-list__actions' })
     end
   end
+
+  context 'when an action is nil' do
+    let(:rows) do
+      [
+        { key: 'One', value: 'First' },
+        { key: 'Two', value: 'Second', action: nil }
+      ]
+    end
+
+    before do
+      render_inline(described_class.new(**kwargs)) do |component|
+        rows.each { |row| component.row(**row) }
+      end
+    end
+
+    specify 'renders the summary list without an actions column' do
+      expect(rendered_component).to have_tag('dl', with: { class: 'govuk-summary-list' })
+      expect(rendered_component).not_to have_tag('dd', with: { class: 'govuk-summary-list__actions' })
+    end
+  end
 end


### PR DESCRIPTION
In addition to an empty hash, now we allow the action to be nil. This makes it more intuitive for developers when using logic to control the action.

Fixes #185
