### PR TITLE
Tidying up instance variables and attr_accessor

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,4 @@
-# .rubocop.yml
+---
 inherit_gem:
   rubocop-govuk:
     - config/default.yml

--- a/app/components/govuk_component/accordion_component.rb
+++ b/app/components/govuk_component/accordion_component.rb
@@ -1,7 +1,7 @@
 class GovukComponent::AccordionComponent < GovukComponent::Base
   renders_many :sections, "Section"
 
-  attr_accessor :id
+  attr_reader :id
 
   def initialize(id: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
@@ -16,24 +16,20 @@ private
   end
 
   class Section < GovukComponent::Base
-    attr_accessor :title, :summary, :expanded
+    attr_reader :title, :summary, :expanded
 
     alias_method :expanded?, :expanded
 
     def initialize(title:, summary: nil, expanded: false, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
-      self.title   = title
-      self.summary = summary
-      self.expanded = expanded
+      @title    = title
+      @summary  = summary
+      @expanded = expanded
     end
 
     def id(suffix: nil)
       [title.parameterize, suffix].compact.join('-')
-    end
-
-    def classes
-      super + (expanded? ? %w(govuk-accordion__section--expanded) : [])
     end
 
     def call
@@ -43,7 +39,9 @@ private
   private
 
     def default_classes
-      %w(govuk-accordion__section)
+      %w(govuk-accordion__section).tap do |classes|
+        classes.append("govuk-accordion__section--expanded") if expanded?
+      end
     end
   end
 end

--- a/app/components/govuk_component/back_link_component.rb
+++ b/app/components/govuk_component/back_link_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::BackLinkComponent < GovukComponent::Base
-  attr_accessor :text, :href, :options
+  attr_reader :text, :href, :options
 
   def initialize(text:, href:, classes: nil, html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
@@ -9,7 +9,7 @@ class GovukComponent::BackLinkComponent < GovukComponent::Base
   end
 
   def call
-    link_to(@text, @href, class: classes, **html_attributes)
+    link_to(text, href, class: classes, **html_attributes)
   end
 
 private

--- a/app/components/govuk_component/breadcrumbs_component.rb
+++ b/app/components/govuk_component/breadcrumbs_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::BreadcrumbsComponent < GovukComponent::Base
-  attr_accessor :breadcrumbs
+  attr_reader :breadcrumbs, :hide_in_print, :collapse_on_mobile
 
   def initialize(breadcrumbs:, hide_in_print: false, collapse_on_mobile: false, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
@@ -13,8 +13,8 @@ private
 
   def default_classes
     %w(govuk-breadcrumbs).tap do |classes|
-      classes << "govuk-!-display-none-print" if @hide_in_print
-      classes << "govuk-breadcrumbs--collapse-on-mobile" if @collapse_on_mobile
+      classes << "govuk-!-display-none-print" if hide_in_print
+      classes << "govuk-breadcrumbs--collapse-on-mobile" if collapse_on_mobile
     end
   end
 end

--- a/app/components/govuk_component/details_component.rb
+++ b/app/components/govuk_component/details_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::DetailsComponent < GovukComponent::Base
-  attr_accessor :summary_text, :text
+  attr_reader :summary_text, :text
 
   renders_one :summary_html
 

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -2,7 +2,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
   renders_one :meta_content
   renders_one :meta
 
-  attr_accessor :meta_items, :meta_items_title, :meta_licence, :copyright
+  attr_reader :meta_items, :meta_items_title, :meta_licence, :copyright
 
   def initialize(meta_items: {}, meta_items_title: "Support links", meta_licence: nil, classes: [], html_attributes: {}, copyright_text: default_copright_text, copyright_url: default_copyright_url)
     super(classes: classes, html_attributes: html_attributes)

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -3,13 +3,15 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
   renders_one :custom_logo
   renders_one :product_name, "ProductName"
 
-  attr_accessor :logotype,
-                :crown,
-                :homepage_url,
-                :service_name,
-                :service_url,
-                :menu_button_label,
-                :navigation_label
+  attr_reader :logotype,
+              :crown,
+              :homepage_url,
+              :service_name,
+              :service_url,
+              :menu_button_label,
+              :navigation_label,
+              :custom_navigation_classes,
+              :custom_container_classes
 
   def initialize(classes: [],
                  html_attributes: {},
@@ -25,15 +27,15 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
 
     super(classes: classes, html_attributes: html_attributes)
 
-    @logotype           = logotype
-    @crown              = crown
-    @homepage_url       = homepage_url
-    @service_name       = service_name
-    @service_url        = service_url
-    @menu_button_label  = menu_button_label
-    @navigation_classes = navigation_classes
-    @navigation_label   = navigation_label
-    @container_classes  = container_classes
+    @logotype                  = logotype
+    @crown                     = crown
+    @homepage_url              = homepage_url
+    @service_name              = service_name
+    @service_url               = service_url
+    @menu_button_label         = menu_button_label
+    @custom_navigation_classes = navigation_classes
+    @navigation_label          = navigation_label
+    @custom_container_classes  = container_classes
   end
 
 private
@@ -43,22 +45,22 @@ private
   end
 
   def navigation_classes
-    combine_classes(%w(govuk-header__navigation), @navigation_classes)
+    combine_classes(%w(govuk-header__navigation), custom_navigation_classes)
   end
 
   def container_classes
-    combine_classes(%w(govuk-header__container govuk-width-container), @container_classes)
+    combine_classes(%w(govuk-header__container govuk-width-container), custom_container_classes)
   end
 
   class Item < GovukComponent::Base
-    attr_accessor :text, :href, :active
+    attr_reader :text, :href, :active
 
     def initialize(text:, href: nil, active: false, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
-      self.text   = text
-      self.href   = href
-      self.active = active
+      @text   = text
+      @href   = href
+      @active = active
     end
 
     def active?
@@ -81,7 +83,7 @@ private
   end
 
   class ProductName < GovukComponent::Base
-    attr_accessor :name
+    attr_reader :name
 
     def initialize(name: nil, html_attributes: {}, classes: [])
       super(classes: classes, html_attributes: html_attributes)
@@ -90,14 +92,14 @@ private
     end
 
     def render?
-      @name.present? || content.present?
+      name.present? || content.present?
     end
 
     def call
       if content.present?
         tag.div(content, class: classes)
       else
-        tag.span(@name, class: classes)
+        tag.span(name, class: classes)
       end
     end
 

--- a/app/components/govuk_component/inset_text_component.rb
+++ b/app/components/govuk_component/inset_text_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::InsetTextComponent < GovukComponent::Base
-  attr_accessor :text
+  attr_reader :text
 
   def initialize(text: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)

--- a/app/components/govuk_component/notification_banner_component.rb
+++ b/app/components/govuk_component/notification_banner_component.rb
@@ -32,14 +32,14 @@ class GovukComponent::NotificationBannerComponent < GovukComponent::Base
   end
 
   class Heading < GovukComponent::Base
-    attr_accessor :text, :link_href, :link_text
+    attr_reader :text, :link_href, :link_text
 
     def initialize(text: nil, link_text: nil, link_href: nil, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
-      @text        = text
-      @link_text   = link_text
-      @link_href   = link_href
+      @text      = text
+      @link_text = link_text
+      @link_href = link_href
     end
 
     def call

--- a/app/components/govuk_component/panel_component.rb
+++ b/app/components/govuk_component/panel_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::PanelComponent < GovukComponent::Base
-  attr_accessor :title, :body
+  attr_reader :title, :body
 
   def initialize(title: nil, body: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
@@ -35,7 +35,7 @@ private
   def panel_body
     if display_body?
       tag.div(class: "govuk-panel__body") do
-        content.presence || @body
+        content.presence || body
       end
     end
   end

--- a/app/components/govuk_component/phase_banner_component.rb
+++ b/app/components/govuk_component/phase_banner_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::PhaseBannerComponent < GovukComponent::Base
-  attr_accessor :text
+  attr_reader :text, :phase_tag
 
   def initialize(phase_tag: nil, text: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
@@ -9,7 +9,7 @@ class GovukComponent::PhaseBannerComponent < GovukComponent::Base
   end
 
   def phase_tag_component
-    GovukComponent::TagComponent.new(classes: "govuk-phase-banner__content__tag", **@phase_tag)
+    GovukComponent::TagComponent.new(classes: "govuk-phase-banner__content__tag", **phase_tag)
   end
 
 private

--- a/app/components/govuk_component/slot.rb
+++ b/app/components/govuk_component/slot.rb
@@ -1,9 +1,0 @@
-class GovukComponent::Slot < ViewComponent::Slot
-  include GovukComponent::Traits::CustomClasses
-  include GovukComponent::Traits::CustomHtmlAttributes
-
-  def initialize(classes: [], html_attributes: {})
-    @classes         = parse_classes(classes)
-    @html_attributes = html_attributes
-  end
-end

--- a/app/components/govuk_component/start_button_component.rb
+++ b/app/components/govuk_component/start_button_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::StartButtonComponent < GovukComponent::Base
-  attr_accessor :text, :href
+  attr_reader :text, :href
 
   def initialize(text:, href:, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
@@ -9,8 +9,8 @@ class GovukComponent::StartButtonComponent < GovukComponent::Base
   end
 
   def call
-    link_to(@href, **default_attributes, **html_attributes) do
-      safe_join([@text, icon])
+    link_to(href, **default_attributes, **html_attributes) do
+      safe_join([text, icon])
     end
   end
 

--- a/app/components/govuk_component/summary_list_component.rb
+++ b/app/components/govuk_component/summary_list_component.rb
@@ -33,8 +33,8 @@ private
     def initialize(key:, value:, action: {}, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
-      @key                  = key
-      @value                = value
+      @key   = key
+      @value = value
 
       if action.present?
         @href                 = action[:href]

--- a/app/components/govuk_component/tag_component.rb
+++ b/app/components/govuk_component/tag_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::TagComponent < GovukComponent::Base
-  attr_reader :text
+  attr_reader :text, :colour
 
   COLOURS = %w(
     grey
@@ -31,11 +31,11 @@ private
   end
 
   def colour_class
-    return nil if @colour.blank?
+    return nil if colour.blank?
 
     fail(ArgumentError, colour_error_message) unless valid_colour?
 
-    %(govuk-tag--#{@colour})
+    %(govuk-tag--#{colour})
   end
 
   def valid_colour?
@@ -43,6 +43,6 @@ private
   end
 
   def colour_error_message
-    "invalid tag colour #{@colour}, supported colours are #{COLOURS.to_sentence}"
+    "invalid tag colour #{colour}, supported colours are #{COLOURS.to_sentence}"
   end
 end

--- a/app/components/govuk_component/warning_text_component.rb
+++ b/app/components/govuk_component/warning_text_component.rb
@@ -6,13 +6,13 @@ class GovukComponent::WarningTextComponent < GovukComponent::Base
   def initialize(text:, assistive_text: 'Warning', classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @text           = text
+    @text = text
     @assistive_text = assistive_text
   end
 
   def call
     tag.div(class: classes, **html_attributes) do
-      safe_join([icon, strong])
+      safe_join([icon, (content || strong)])
     end
   end
 

--- a/app/components/govuk_component/warning_text_component.rb
+++ b/app/components/govuk_component/warning_text_component.rb
@@ -6,7 +6,7 @@ class GovukComponent::WarningTextComponent < GovukComponent::Base
   def initialize(text:, assistive_text: 'Warning', classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @text = text
+    @text           = text
     @assistive_text = assistive_text
   end
 

--- a/spec/components/govuk_component/warning_text_component_spec.rb
+++ b/spec/components/govuk_component/warning_text_component_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(GovukComponent::WarningTextComponent, type: :component) do
+  include_context 'helpers'
   include_context 'setup'
 
   let(:component_css_class) { 'govuk-warning-text' }
@@ -43,6 +44,24 @@ RSpec.describe(GovukComponent::WarningTextComponent, type: :component) do
   specify 'the warning text is included' do
     expect(rendered_component).to have_tag(component_css_class_matcher) do
       with_tag('strong', text: Regexp.new(text), with: { class: 'govuk-warning-text__text' })
+    end
+  end
+
+  context 'overriding the text with a custom HTML block' do
+    let(:custom_tag) { "marquee" }
+    let(:custom_text) { "Fancy HTML" }
+    let(:custom_html) { helper.content_tag(custom_tag, custom_text) }
+
+    subject! do
+      render_inline(GovukComponent::WarningTextComponent.new(**kwargs)) { custom_html }
+    end
+
+    specify "renders the custom html" do
+      expect(rendered_component).to have_tag(custom_tag, text: custom_text)
+    end
+
+    specify "doesn't render any provided text" do
+      expect(rendered_component).not_to match(text)
     end
   end
 


### PR DESCRIPTION
- Remove no-longer-needed GovukComponent::Slot
- Use attr_reader instead of instance variables
- Start the YAML doc with three dashes
- Allow warning text component to take content block
