### PR TITLE
Add some extra class options to link helpers

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -1,10 +1,14 @@
 module GovukLinkHelper
-  def govuk_link_to(*args, button: false, **kwargs, &block)
-    link_to(*args, **inject_class(kwargs, class_name: link_class(button)), &block)
+  def govuk_link_to(*args, button: false, no_visited_state: false, muted: false, colour: false, inverse: false, no_underline: false, **kwargs, &block)
+    classes = build_classes(button, no_visited_state, muted, colour, inverse, no_underline)
+
+    link_to(*args, **inject_class(kwargs, class_name: classes), &block)
   end
 
-  def govuk_mail_to(*args, button: false, **kwargs, &block)
-    mail_to(*args, **inject_class(kwargs, class_name: link_class(button)), &block)
+  def govuk_mail_to(*args, button: false, no_visited_state: false, muted: false, colour: false, inverse: false, no_underline: false, **kwargs, &block)
+    classes = build_classes(button, no_visited_state, muted, colour, inverse, no_underline)
+
+    mail_to(*args, **inject_class(kwargs, class_name: classes), &block)
   end
 
   def govuk_button_to(*args, **kwargs)
@@ -12,6 +16,17 @@ module GovukLinkHelper
   end
 
 private
+
+  def build_classes(button, no_visited_state, muted, colour, inverse, no_underline)
+    [
+      link_class(button),
+      no_visited_state_class(no_visited_state),
+      muted_class(muted),
+      colour_class(colour),
+      inverse_class(inverse),
+      no_underline_class(no_underline),
+    ]
+  end
 
   def inject_class(attributes, class_name:)
     attributes.with_indifferent_access.tap do |attrs|
@@ -21,6 +36,26 @@ private
 
   def link_class(button)
     button ? 'govuk-button' : 'govuk-link'
+  end
+
+  def no_visited_state_class(no_visited_state)
+    'govuk-link--no-visited-state' if no_visited_state
+  end
+
+  def muted_class(muted)
+    'govuk-link--muted' if muted
+  end
+
+  def colour_class(colour)
+    'govuk-link--colour' if colour
+  end
+
+  def inverse_class(inverse)
+    'govuk-link--inverse' if inverse
+  end
+
+  def no_underline_class(no_underline)
+    'govuk-link--no-underline' if no_underline
   end
 end
 

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -47,6 +47,46 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
         expect(subject).to(have_link(text, href: url, class: 'govuk-button'))
       end
     end
+
+    describe 'generating a no_visited_state link' do
+      let(:component) { govuk_link_to(text, url, no_visited_state: true) }
+
+      specify 'has the no-visted-state class' do
+        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--no-visited-state'))
+      end
+    end
+
+    describe 'generating a muted link' do
+      let(:component) { govuk_link_to(text, url, muted: true) }
+
+      specify 'has the muted class' do
+        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--muted'))
+      end
+    end
+
+    describe 'generating a coloured link' do
+      let(:component) { govuk_link_to(text, url, colour: true) }
+
+      specify 'has the coloured class' do
+        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--colour'))
+      end
+    end
+
+    describe 'generating a inverse link' do
+      let(:component) { govuk_link_to(text, url, inverse: true) }
+
+      specify 'has the inverse class' do
+        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--inverse'))
+      end
+    end
+
+    describe 'generating a no-underline link' do
+      let(:component) { govuk_link_to(text, url, no_underline: true) }
+
+      specify 'has the no-underline class' do
+        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--no-underline'))
+      end
+    end
   end
 
   describe '#govuk_mail_to' do
@@ -80,6 +120,54 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify 'should render a link containing the block content' do
         expect(subject).to have_css('a > span', text: link_text)
+      end
+    end
+
+    describe 'generating a button-style link' do
+      let(:component) { govuk_link_to(text, email_address, button: true) }
+
+      specify 'has the button class' do
+        expect(subject).to(have_link(text, class: 'govuk-button'))
+      end
+    end
+
+    describe 'generating a no_visited_state link' do
+      let(:component) { govuk_link_to(text, email_address, no_visited_state: true) }
+
+      specify 'has the no-visted-state class' do
+        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--no-visited-state'))
+      end
+    end
+
+    describe 'generating a muted link' do
+      let(:component) { govuk_link_to(text, email_address, muted: true) }
+
+      specify 'has the muted class' do
+        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--muted'))
+      end
+    end
+
+    describe 'generating a coloured link' do
+      let(:component) { govuk_link_to(text, email_address, colour: true) }
+
+      specify 'has the coloured class' do
+        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--colour'))
+      end
+    end
+
+    describe 'generating a inverse link' do
+      let(:component) { govuk_link_to(text, email_address, inverse: true) }
+
+      specify 'has the inverse class' do
+        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--inverse'))
+      end
+    end
+
+    describe 'generating a no-underline link' do
+      let(:component) { govuk_link_to(text, email_address, no_underline: true) }
+
+      specify 'has the inverse class' do
+        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--no-underline'))
       end
     end
   end

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -5,205 +5,180 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
   include ActionView::Context
 
   let(:text) { 'Menu' }
-  subject { Capybara::Node::Simple.new(component) }
+  let(:url) { '/stuff/menu/' }
+  let(:args) { [text, url] }
+  let(:kwargs) { {} }
 
   describe '#govuk_link_to' do
-    let(:url) { '/stuff/menu/' }
-    let(:component) { govuk_link_to(text, url) }
-    it { is_expected.to(have_link(text, href: url, class: 'govuk-link')) }
+    subject { govuk_link_to(*args, **kwargs) }
+    it { is_expected.to have_tag("a", with: { href: url, class: 'govuk-link' }) }
 
-    context 'when additional classes are passed in' do
-      let(:custom_class) { 'yellow' }
-      let(:component) { govuk_link_to(text, url, class: custom_class) }
+    describe "custom classes" do
+      context 'when additional classes are passed in as strings' do
+        let(:custom_class) { 'yellow' }
+        let(:kwargs) { { class: custom_class } }
 
-      specify 'has the custom classes' do
-        expect(subject).to(have_link(text, href: url, class: ['govuk-link', custom_class]))
+        specify 'has the custom classes' do
+          expect(subject).to have_tag("a", with: { href: url, class: ['govuk-link', custom_class] })
+        end
       end
-    end
 
-    context 'when additional classes are passed in as arrays' do
-      let(:custom_class) { %w(yellow) }
-      let(:component) { govuk_link_to(text, url, class: custom_class) }
+      context 'when additional classes are passed in as arrays' do
+        let(:custom_class) { %w(yellow) }
+        let(:kwargs) { { class: custom_class } }
 
-      specify 'has the custom classes' do
-        expect(subject).to(have_link(text, href: url, class: ['govuk-link', custom_class].flatten))
+        specify 'has the custom classes' do
+          expect(subject).to have_tag("a", with: { href: url, class: custom_class.append("govuk-link") })
+        end
       end
     end
 
     context 'when provided with a block' do
       let(:link_text) { 'Onwards!' }
       let(:link_html) { tag.span(link_text) }
-      let(:component) { govuk_link_to(url) { link_html } }
+      subject { govuk_link_to(url) { link_html } }
 
-      specify 'should render a link containing the block content' do
-        expect(subject).to have_css('a > span', text: link_text)
+      specify 'renders a link containing the block content' do
+        expect(subject).to have_tag('a') do
+          with_tag('span', text: link_text)
+        end
       end
     end
 
-    describe 'generating a button-style link' do
-      let(:component) { govuk_link_to(text, url, button: true) }
+    {
+      button: %w(govuk-button),
+      no_visited_state: %w(govuk-link govuk-link--no-visited-state),
+      muted: %w(govuk-link govuk-link--muted),
+      colour: %w(govuk-link govuk-link--colour),
+      inverse: %w(govuk-link govuk-link--inverse),
+      no_underline: %w(govuk-link govuk-link--no-underline),
+    }.each do |style, css_class|
+      describe "generating a #{style}-style link with '#{style}: true'" do
+        let(:kwargs) { { style => true } }
 
-      specify 'has the button class' do
-        expect(subject).to(have_link(text, href: url, class: 'govuk-button'))
-      end
-    end
-
-    describe 'generating a no_visited_state link' do
-      let(:component) { govuk_link_to(text, url, no_visited_state: true) }
-
-      specify 'has the no-visted-state class' do
-        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--no-visited-state'))
-      end
-    end
-
-    describe 'generating a muted link' do
-      let(:component) { govuk_link_to(text, url, muted: true) }
-
-      specify 'has the muted class' do
-        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--muted'))
-      end
-    end
-
-    describe 'generating a coloured link' do
-      let(:component) { govuk_link_to(text, url, colour: true) }
-
-      specify 'has the coloured class' do
-        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--colour'))
-      end
-    end
-
-    describe 'generating a inverse link' do
-      let(:component) { govuk_link_to(text, url, inverse: true) }
-
-      specify 'has the inverse class' do
-        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--inverse'))
-      end
-    end
-
-    describe 'generating a no-underline link' do
-      let(:component) { govuk_link_to(text, url, no_underline: true) }
-
-      specify 'has the no-underline class' do
-        expect(subject).to(have_link(text, href: url, class: 'govuk-link govuk-link--no-underline'))
+        specify "link has the class: #{css_class}" do
+          expect(subject).to have_tag('a', text: text, with: { href: url, class: css_class })
+        end
       end
     end
   end
 
   describe '#govuk_mail_to' do
     let(:email_address) { %(test@something.org) }
-    let(:target) { %(mailto:) + email_address }
-    let(:component) { govuk_mail_to(email_address, text) }
-    it { is_expected.to(have_link(text, href: target, class: 'govuk-link')) }
+    let(:email_address_with_mailto_prefix) { %(mailto:) + email_address }
+    let(:args) { [email_address, text] }
+    subject { govuk_mail_to(*args, **kwargs) }
 
-    context 'when additional classes are passed in' do
-      let(:custom_class) { 'yellow' }
-      let(:component) { govuk_mail_to(email_address, text, class: custom_class) }
+    it { is_expected.to have_tag("a", with: { href: email_address_with_mailto_prefix, class: 'govuk-link' }) }
 
-      specify 'has the custom classes' do
-        expect(subject).to(have_link(text, href: target, class: ['govuk-link', custom_class]))
+    describe "custom classes" do
+      context 'when additional classes are passed in as strings' do
+        let(:custom_class) { 'yellow' }
+        let(:kwargs) { { class: custom_class } }
+
+        specify 'has the custom classes' do
+          expect(subject).to have_tag("a", with: { href: email_address_with_mailto_prefix, class: ['govuk-link', custom_class] })
+        end
       end
-    end
 
-    context 'when additional classes are passed in as arrays' do
-      let(:custom_class) { %w(yellow) }
-      let(:component) { govuk_mail_to(email_address, text, class: custom_class) }
+      context 'when additional classes are passed in as arrays' do
+        let(:custom_class) { %w(yellow) }
+        let(:kwargs) { { class: custom_class } }
 
-      specify 'has the custom classes' do
-        expect(subject).to(have_link(text, href: target, class: ['govuk-link', custom_class].flatten))
+        specify 'has the custom classes' do
+          expect(subject).to have_tag("a", with: { href: email_address_with_mailto_prefix, class: custom_class.append("govuk-link") })
+        end
       end
     end
 
     context 'when provided with a block' do
-      let(:link_text) { 'Contact us!' }
+      let(:link_text) { 'Onwards!' }
       let(:link_html) { tag.span(link_text) }
-      let(:component) { govuk_mail_to(email_address) { link_html } }
+      subject { govuk_link_to(url) { link_html } }
 
-      specify 'should render a link containing the block content' do
-        expect(subject).to have_css('a > span', text: link_text)
+      specify 'renders a link containing the block content' do
+        expect(subject).to have_tag('a') do
+          with_tag('span', text: link_text)
+        end
       end
     end
 
-    describe 'generating a button-style link' do
-      let(:component) { govuk_link_to(text, email_address, button: true) }
+    {
+      button: %w(govuk-button),
+      no_visited_state: %w(govuk-link govuk-link--no-visited-state),
+      muted: %w(govuk-link govuk-link--muted),
+      colour: %w(govuk-link govuk-link--colour),
+      inverse: %w(govuk-link govuk-link--inverse),
+      no_underline: %w(govuk-link govuk-link--no-underline),
+    }.each do |style, css_class|
+      describe "generating a #{style}-style link with '#{style}: true'" do
+        let(:kwargs) { { style => true } }
 
-      specify 'has the button class' do
-        expect(subject).to(have_link(text, class: 'govuk-button'))
-      end
-    end
-
-    describe 'generating a no_visited_state link' do
-      let(:component) { govuk_link_to(text, email_address, no_visited_state: true) }
-
-      specify 'has the no-visted-state class' do
-        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--no-visited-state'))
-      end
-    end
-
-    describe 'generating a muted link' do
-      let(:component) { govuk_link_to(text, email_address, muted: true) }
-
-      specify 'has the muted class' do
-        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--muted'))
-      end
-    end
-
-    describe 'generating a coloured link' do
-      let(:component) { govuk_link_to(text, email_address, colour: true) }
-
-      specify 'has the coloured class' do
-        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--colour'))
-      end
-    end
-
-    describe 'generating a inverse link' do
-      let(:component) { govuk_link_to(text, email_address, inverse: true) }
-
-      specify 'has the inverse class' do
-        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--inverse'))
-      end
-    end
-
-    describe 'generating a no-underline link' do
-      let(:component) { govuk_link_to(text, email_address, no_underline: true) }
-
-      specify 'has the inverse class' do
-        expect(subject).to(have_link(text, class: 'govuk-link govuk-link--no-underline'))
+        specify "link has the class: #{css_class}" do
+          expect(subject).to have_tag('a', text: text, with: { href: email_address_with_mailto_prefix, class: css_class })
+        end
       end
     end
   end
 
   describe '#govuk_button_to' do
+    subject { govuk_button_to(*args, **kwargs) }
     let(:url) { '/stuff/menu/' }
-    let(:component) { govuk_button_to(text, url) }
-    it { is_expected.to(have_button(text, class: 'govuk-button')) }
 
     specify 'has form with correct url containing submit input with supplied text' do
-      expect(subject).to have_css(%(form)) do |form|
-        expect(form['action']).to eql(url)
-        expect(form).to have_button(text, class: 'govuk-button')
+      # expect(subject).to have_css(%(form)) do |form|
+      #   expect(form['action']).to eql(url)
+      #   expect(form).to have_button(text, class: 'govuk-button')
+      # end
+      expect(subject).to have_tag('form', with: { action: url }) do
+        with_tag('input', with: { class: 'govuk-button', value: text })
       end
     end
 
-    context 'when additional classes are passed in' do
-      let(:custom_class) { 'yellow' }
-      let(:component) { govuk_button_to(text, url, class: custom_class) }
+    describe "custom classes" do
+      context 'when additional classes are passed in as strings' do
+        let(:custom_class) { 'yellow' }
+        let(:kwargs) { { class: custom_class } }
 
-      specify 'has the custom classes' do
-        expect(subject).to(have_button(text, class: ['govuk-button', custom_class].flatten))
+        specify 'has the custom classes' do
+          expect(subject).to have_tag('form', with: { action: url }) do
+            with_tag("input", with: { class: ['govuk-button', custom_class] })
+          end
+        end
       end
 
-      specify 'has the default class' do
-        expect(subject).to(have_button(text, class: 'govuk-button'))
+      context 'when additional classes are passed in as arrays' do
+        let(:custom_class) { %w(yellow) }
+        let(:kwargs) { { class: custom_class } }
+
+        specify 'has the custom classes' do
+          expect(subject).to have_tag('form', with: { action: url }) do
+            with_tag("input", with: { class: ['govuk-button', custom_class] })
+          end
+        end
       end
     end
 
-    context 'when additional classes are passed in as arrays' do
-      let(:custom_class) { %w(yellow) }
-      let(:component) { govuk_button_to(text, url, class: custom_class) }
+    # context 'when additional classes are passed in' do
+    #   let(:custom_class) { 'yellow' }
+    #   let(:component) { govuk_button_to(text, url, class: custom_class) }
 
-      specify 'has the custom classes' do
-        expect(subject).to(have_button(text, class: custom_class))
-      end
-    end
+    #   specify 'has the custom classes' do
+    #     expect(subject).to(have_button(text, class: ['govuk-button', custom_class].flatten))
+    #   end
+
+    #   specify 'has the default class' do
+    #     expect(subject).to(have_button(text, class: 'govuk-button'))
+    #   end
+    # end
+
+    # context 'when additional classes are passed in as arrays' do
+    #   let(:custom_class) { %w(yellow) }
+    #   let(:component) { govuk_button_to(text, url, class: custom_class) }
+
+    #   specify 'has the custom classes' do
+    #     expect(subject).to(have_button(text, class: custom_class))
+    #   end
+    # end
   end
 end


### PR DESCRIPTION
GOV.UK frontend links support several modifier classes:

* `.govuk-link--muted`
* `.govuk-link--text-colour`
* `.govuk-link--inverse`
* `.govuk-link--no-underline`
* `.govuk-link--no-visited-state`

Now both the `#govuk_link_to` and `#govuk_mail_to` helper have keyword arguments `no_visited_state`, `muted`, `colour`, `inverse` and `no_underline` that default to false. Toggling them to true will add the approproate class.

Fixes #176
