### PR TITLE
Replace link helpers with link class helpers

### DIFF
--- a/app/components/govuk_component/summary_list_component.rb
+++ b/app/components/govuk_component/summary_list_component.rb
@@ -46,9 +46,11 @@ private
     end
 
     def action
+      link_classes = govuk_link_classes.append(action_classes).flatten
+
       tag.dd(class: "govuk-summary-list__actions") do
         if href.present?
-          govuk_link_to(href, class: action_classes, **action_attributes) do
+          link_to(href, class: link_classes, **action_attributes) do
             safe_join([text, tag.span(visually_hidden_text, class: "govuk-visually-hidden")])
           end
         end

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -7,11 +7,15 @@ module GovukLinkHelper
     no_underline: "govuk-link--no-underline",
   }.freeze
 
-  def govuk_link_to(name = nil, options = nil, extra_options = [], &block)
+  def govuk_link_to(name = nil, options = nil, extra_options = {}, &block)
     extra_options = options if block_given?
 
-    html_options = if (style_classes = govuk_link_classes(*extra_options))
-                     inject_class(html_options, class_name: style_classes)
+    govuk_link_style_options = extra_options&.slice(*LINK_STYLES.keys) || {}
+
+    html_options = if (style_classes = govuk_link_classes(*govuk_link_style_options.keys))
+                     inject_class(extra_options, class_name: style_classes)
+                   else
+                     {}
                    end
 
     if block_given?
@@ -45,7 +49,7 @@ private
     attributes ||= {}
 
     attributes.with_indifferent_access.tap do |attrs|
-      attrs[:class] = Array.wrap(attrs[:class]).prepend(class_name)
+      attrs[:class] = Array.wrap(attrs[:class]).prepend(class_name).flatten
     end
   end
 

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -10,6 +10,60 @@ module GovukLinkHelper
     ].compact
   end
 
+  EXTRA_OPTIONS = {
+    button: false,
+    no_visited_state: false,
+    muted: false,
+    text_colour: false,
+    inverse: false,
+    no_underline: false
+  }.freeze
+
+  def govuk_link_to(name = nil, options = nil, extra_options = {}, &block)
+    extra_options = options if block_given?
+
+    html_options = extra_options&.slice!(*EXTRA_OPTIONS.keys) || {}
+    extra_options = EXTRA_OPTIONS.merge(extra_options || {})
+
+    classes = build_classes(*extra_options.values_at(*EXTRA_OPTIONS.keys))
+    html_options = inject_class(html_options, class_name: classes)
+
+    if block_given?
+      link_to(name, html_options, &block)
+    else
+      link_to(name, options, html_options)
+    end
+  end
+
+  def govuk_mail_to(*args, button: false, no_visited_state: false, muted: false, text_colour: false, inverse: false, no_underline: false, **kwargs, &block)
+    classes = build_classes(button, no_visited_state, muted, text_colour, inverse, no_underline)
+
+    mail_to(*args, **inject_class(kwargs, class_name: classes), &block)
+  end
+
+  def govuk_button_to(*args, **kwargs)
+    button_to(*args, **inject_class(kwargs, class_name: 'govuk-button'))
+  end
+
+private
+
+  def build_classes(button, no_visited_state, muted, text_colour, inverse, no_underline)
+    [
+      link_class(button),
+      no_visited_state_class(no_visited_state),
+      muted_class(muted),
+      text_colour_class(text_colour),
+      inverse_class(inverse),
+      no_underline_class(no_underline),
+    ].compact.join(" ")
+  end
+
+  def inject_class(attributes, class_name:)
+    attributes.with_indifferent_access.tap do |attrs|
+      attrs[:class] = Array.wrap(attrs[:class]).prepend(class_name)
+    end
+  end
+
   def govuk_button_classes(secondary: false, warning: false, disabled: false)
     [
       'govuk-button',
@@ -19,14 +73,16 @@ module GovukLinkHelper
     ].compact
   end
 
-private
-
-  def no_visited_state_class(no_visited_state)
-    'govuk-link--no-visited-state' if no_visited_state
+  def link_class(button)
+    button ? 'govuk-button' : 'govuk-link'
   end
 
   def muted_class(muted)
     'govuk-link--muted' if muted
+  end
+
+  def no_visited_state_class(no_visited_state)
+    'govuk-link--no-visited-state' if no_visited_state
   end
 
   def text_colour_class(colour)

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -1,42 +1,25 @@
 module GovukLinkHelper
-  def govuk_link_to(*args, button: false, no_visited_state: false, muted: false, text_colour: false, inverse: false, no_underline: false, **kwargs, &block)
-    classes = build_classes(button, no_visited_state, muted, text_colour, inverse, no_underline)
-
-    link_to(*args, **inject_class(kwargs, class_name: classes), &block)
-  end
-
-  def govuk_mail_to(*args, button: false, no_visited_state: false, muted: false, text_colour: false, inverse: false, no_underline: false, **kwargs, &block)
-    classes = build_classes(button, no_visited_state, muted, text_colour, inverse, no_underline)
-
-    mail_to(*args, **inject_class(kwargs, class_name: classes), &block)
-  end
-
-  def govuk_button_to(*args, **kwargs)
-    button_to(*args, **inject_class(kwargs, class_name: 'govuk-button'))
-  end
-
-private
-
-  def build_classes(button, no_visited_state, muted, text_colour, inverse, no_underline)
+  def govuk_link_classes(no_visited_state: false, muted: false, text_colour: false, inverse: false, no_underline: false)
     [
-      link_class(button),
+      'govuk-link',
       no_visited_state_class(no_visited_state),
       muted_class(muted),
       text_colour_class(text_colour),
       inverse_class(inverse),
       no_underline_class(no_underline),
-    ]
+    ].compact
   end
 
-  def inject_class(attributes, class_name:)
-    attributes.with_indifferent_access.tap do |attrs|
-      attrs[:class] = Array.wrap(attrs[:class]).prepend(class_name)
-    end
+  def govuk_button_classes(secondary: false, warning: false, disabled: false)
+    [
+      'govuk-button',
+      secondary_class(secondary),
+      warning_class(warning),
+      disabled_class(disabled)
+    ].compact
   end
 
-  def link_class(button)
-    button ? 'govuk-button' : 'govuk-link'
-  end
+private
 
   def no_visited_state_class(no_visited_state)
     'govuk-link--no-visited-state' if no_visited_state
@@ -56,6 +39,18 @@ private
 
   def no_underline_class(no_underline)
     'govuk-link--no-underline' if no_underline
+  end
+
+  def secondary_class(secondary)
+    'govuk-button--secondary' if secondary
+  end
+
+  def warning_class(warning)
+    'govuk-button--warning' if warning
+  end
+
+  def disabled_class(disabled)
+    'govuk-button--disabled' if disabled
   end
 end
 

--- a/spec/components/govuk_component/cookie_banner_component_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_component_spec.rb
@@ -18,9 +18,9 @@ RSpec.describe(GovukComponent::CookieBannerComponent, type: :component) do
   let(:actions) do
     helper.safe_join(
       [
-        helper.govuk_button_to("Accept", "/accept-path"),
-        helper.govuk_button_to("Reject", "/reject-path"),
-        helper.govuk_link_to("View", "/view-path"),
+        helper.button_to("Accept", "/accept-path"),
+        helper.button_to("Reject", "/reject-path"),
+        helper.link_to("View", "/view-path"),
       ]
     )
   end

--- a/spec/dummy/app/views/demos/examples/_cookie_banner.html.erb
+++ b/spec/dummy/app/views/demos/examples/_cookie_banner.html.erb
@@ -10,9 +10,9 @@
     end
     component.actions do
       safe_join([
-        govuk_link_to("Accept cookies", "#accept", button: true),
-        govuk_link_to("Reject cookies", "#reject", button: true),
-        govuk_link_to("View cookies", "#view"),
+        link_to("Accept cookies", "#accept", { class: govuk_button_classes }),
+        link_to("Reject cookies", "#reject", { class: govuk_button_classes(warning: true) }),
+        link_to("View cookies", "#view", { class: govuk_link_classes }),
       ])
     end
   end

--- a/spec/dummy/app/views/demos/examples/_links.html.erb
+++ b/spec/dummy/app/views/demos/examples/_links.html.erb
@@ -1,11 +1,12 @@
 <%= example_heading('Links and buttons') %>
 
-<%= render "shared/example", title: 'Links', example: %{govuk_link_to('Home', '/')} %>
-<%= render "shared/example", title: 'Links styled like buttons', example: %{govuk_link_to('Continue', '/', button: true)} %>
-<%= render "shared/example", title: 'Email links', example: %{govuk_mail_to('Home', 'test@test.org')} %>
-<%= render "shared/example", title: 'Button links (this will render a form that POSTs)', example: %{govuk_button_to('Home', '/')} %>
-<%= render "shared/example", title: 'Text-coloured links', example: %{govuk_link_to('Continue', '/', text_colour: true)} %>
-<%= render "shared/example", title: 'No-visited state links', example: %{govuk_link_to('Continue', '/', no_visited_state: true)} %>
-<%= render "shared/example", title: 'Inverse links', example: %{govuk_link_to('Continue', '/', inverse: true)} %>
-<%= render "shared/example", title: 'No-underline links', example: %{govuk_link_to('Continue', '/', no_underline: true)} %>
-<%= render "shared/example", title: 'Muted links', example: %{govuk_link_to('Continue', '/', muted: true)} %>
+<%= render "shared/example", title: 'Links', example: %{link_to('Home', '/', { class: govuk_link_classes })} %>
+<%= render "shared/example", title: 'Links styled like buttons', example: %{link_to('Continue', '/', class: govuk_button_classes)} %>
+<%= render "shared/example", title: 'Email links', example: %{mail_to('Home', 'test@test.org', class: govuk_link_classes)} %>
+<%= render "shared/example", title: 'Text-coloured links', example: %{link_to('Continue', '/', class: govuk_link_classes(text_colour: true))} %>
+<%= render "shared/example", title: 'No-visited state links', example: %{link_to('Continue', '/', class: govuk_link_classes(no_visited_state: true))} %>
+<%= render "shared/example", title: 'Inverse links', example: %{link_to('Continue', '/', class: govuk_link_classes(inverse: true))} %>
+<%= render "shared/example", title: 'No-underline links', example: %{link_to('Continue', '/', class: govuk_link_classes(no_underline: true))} %>
+<%= render "shared/example", title: 'Muted links', example: %{link_to('Continue', '/', class: govuk_link_classes(muted: true))} %>
+
+<%= render "shared/example", title: 'Button links (this will render a form that POSTs)', example: %{button_to('Home', '/', class: govuk_button_classes)} %>

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -9,148 +9,55 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
   let(:args) { [text, url] }
   let(:kwargs) { {} }
 
-  describe '#govuk_link_to' do
-    subject { govuk_link_to(*args, **kwargs) }
-    it { is_expected.to have_tag("a", with: { href: url, class: 'govuk-link' }) }
+  describe '#govuk_link_classes' do
+    subject { govuk_link_classes(**kwargs) }
 
-    describe "custom classes" do
-      context 'when additional classes are passed in as strings' do
-        let(:custom_class) { 'yellow' }
-        let(:kwargs) { { class: custom_class } }
+    describe "by default" do
+      let(:kwargs) { {} }
 
-        specify 'has the custom classes' do
-          expect(subject).to have_tag("a", with: { href: url, class: ['govuk-link', custom_class] })
-        end
-      end
-
-      context 'when additional classes are passed in as arrays' do
-        let(:custom_class) { %w(yellow) }
-        let(:kwargs) { { class: custom_class } }
-
-        specify 'has the custom classes' do
-          expect(subject).to have_tag("a", with: { href: url, class: custom_class.append("govuk-link") })
-        end
-      end
-    end
-
-    context 'when provided with a block' do
-      let(:link_text) { 'Onwards!' }
-      let(:link_html) { tag.span(link_text) }
-      subject { govuk_link_to(url) { link_html } }
-
-      specify 'renders a link containing the block content' do
-        expect(subject).to have_tag('a') do
-          with_tag('span', text: link_text)
-        end
+      specify "contains only 'govuk-link'" do
+        expect(subject).to eql(%w(govuk-link))
       end
     end
 
     {
-      button: %w(govuk-button),
-      no_visited_state: %w(govuk-link govuk-link--no-visited-state),
-      muted: %w(govuk-link govuk-link--muted),
-      text_colour: %w(govuk-link govuk-link--text-colour),
-      inverse: %w(govuk-link govuk-link--inverse),
-      no_underline: %w(govuk-link govuk-link--no-underline),
+      no_visited_state: 'govuk-link--no-visited-state',
+      muted:            'govuk-link--muted',
+      text_colour:      'govuk-link--text-colour',
+      inverse:          'govuk-link--inverse',
+      no_underline:     'govuk-link--no-underline',
     }.each do |style, css_class|
       describe "generating a #{style}-style link with '#{style}: true'" do
         let(:kwargs) { { style => true } }
 
-        specify "link has the class: #{css_class}" do
-          expect(subject).to have_tag('a', text: text, with: { href: url, class: css_class })
+        specify %(contains 'govuk-link' and '#{css_class}') do
+          expect(subject).to match_array(['govuk-link', css_class])
         end
       end
     end
   end
 
-  describe '#govuk_mail_to' do
-    let(:email_address) { %(test@something.org) }
-    let(:email_address_with_mailto_prefix) { %(mailto:) + email_address }
-    let(:args) { [email_address, text] }
-    subject { govuk_mail_to(*args, **kwargs) }
+  describe '#govuk_button_classes' do
+    subject { govuk_button_classes(**kwargs) }
 
-    it { is_expected.to have_tag("a", with: { href: email_address_with_mailto_prefix, class: 'govuk-link' }) }
+    describe "by default" do
+      let(:kwargs) { {} }
 
-    describe "custom classes" do
-      context 'when additional classes are passed in as strings' do
-        let(:custom_class) { 'yellow' }
-        let(:kwargs) { { class: custom_class } }
-
-        specify 'has the custom classes' do
-          expect(subject).to have_tag("a", with: { href: email_address_with_mailto_prefix, class: ['govuk-link', custom_class] })
-        end
-      end
-
-      context 'when additional classes are passed in as arrays' do
-        let(:custom_class) { %w(yellow) }
-        let(:kwargs) { { class: custom_class } }
-
-        specify 'has the custom classes' do
-          expect(subject).to have_tag("a", with: { href: email_address_with_mailto_prefix, class: custom_class.append("govuk-link") })
-        end
-      end
-    end
-
-    context 'when provided with a block' do
-      let(:link_text) { 'Onwards!' }
-      let(:link_html) { tag.span(link_text) }
-      subject { govuk_link_to(url) { link_html } }
-
-      specify 'renders a link containing the block content' do
-        expect(subject).to have_tag('a') do
-          with_tag('span', text: link_text)
-        end
+      specify "contains only 'govuk-link'" do
+        expect(subject).to eql(%w(govuk-button))
       end
     end
 
     {
-      button: %w(govuk-button),
-      no_visited_state: %w(govuk-link govuk-link--no-visited-state),
-      muted: %w(govuk-link govuk-link--muted),
-      text_colour: %w(govuk-link govuk-link--text-colour),
-      inverse: %w(govuk-link govuk-link--inverse),
-      no_underline: %w(govuk-link govuk-link--no-underline),
+      secondary: 'govuk-button--secondary',
+      warning:   'govuk-button--warning',
+      disabled:  'govuk-button--disabled',
     }.each do |style, css_class|
-      describe "generating a #{style}-style link with '#{style}: true'" do
+      describe "generating a #{style}-style button with '#{style}: true'" do
         let(:kwargs) { { style => true } }
 
-        specify "link has the class: #{css_class}" do
-          expect(subject).to have_tag('a', text: text, with: { href: email_address_with_mailto_prefix, class: css_class })
-        end
-      end
-    end
-  end
-
-  describe '#govuk_button_to' do
-    subject { govuk_button_to(*args, **kwargs) }
-    let(:url) { '/stuff/menu/' }
-
-    specify 'has form with correct url containing submit input with supplied text' do
-      expect(subject).to have_tag('form', with: { action: url }) do
-        with_tag('input', with: { class: 'govuk-button', value: text })
-      end
-    end
-
-    describe "custom classes" do
-      context 'when additional classes are passed in as strings' do
-        let(:custom_class) { 'yellow' }
-        let(:kwargs) { { class: custom_class } }
-
-        specify 'has the custom classes' do
-          expect(subject).to have_tag('form', with: { action: url }) do
-            with_tag("input", with: { class: ['govuk-button', custom_class] })
-          end
-        end
-      end
-
-      context 'when additional classes are passed in as arrays' do
-        let(:custom_class) { %w(yellow) }
-        let(:kwargs) { { class: custom_class } }
-
-        specify 'has the custom classes' do
-          expect(subject).to have_tag('form', with: { action: url }) do
-            with_tag("input", with: { class: ['govuk-button', custom_class] })
-          end
+        specify %(contains 'govuk-button' and '#{css_class}') do
+          expect(subject).to match_array(['govuk-button', css_class])
         end
       end
     end

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -38,33 +38,46 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
   end
 
   describe "#govuk_link_to" do
+    let(:link_text) { 'Onwards!' }
+    let(:link_url) { '/some/link' }
+
+    before do
+      allow(self).to receive(:url_for).with(link_params).and_return(link_url)
+    end
+
     context "when provided with link text and url params" do
-      let(:link_text) { 'Onwards!' }
       let(:link_params) { { controller: :some_controller, action: :some_action } }
-      let(:link_url) { '/some/link' }
 
       subject { govuk_link_to link_text, link_params }
-
-      before do
-        allow(self).to receive(:url_for).with(link_params).and_return link_url
-      end
 
       it { is_expected.to have_tag('a', text: link_text, with: { href: link_url, class: 'govuk-link' }) }
     end
 
     context "when provided with url params and the block" do
-      let(:link_text) { 'Onwards!' }
       let(:link_html) { tag.span(link_text) }
       let(:link_params) { { controller: :some_controller, action: :some_action } }
-      let(:link_url) { '/some/link' }
 
       subject { govuk_link_to(link_params) { link_html } }
 
-      before do
-        allow(self).to receive(:url_for).with(link_params).and_return link_url
-      end
-
       it { is_expected.to have_tag('a', with: { href: link_url }) { with_tag(:span, text: link_text) } }
+    end
+
+    context "customising the GOV.UK link style" do
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+      let(:custom_html_options) { { inverse: true } }
+
+      subject { govuk_link_to(link_text, link_params, custom_html_options) }
+
+      it { is_expected.to have_tag('a', with: { href: link_url, class: "govuk-link--inverse" }, text: link_text) }
+    end
+
+    context "adding custom classes" do
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+      let(:custom_class) { { class: "green" } }
+
+      subject { govuk_link_to(link_text, link_params, { class: "green" }) }
+
+      it { is_expected.to have_tag('a', with: { href: link_url, class: "green" }, text: link_text) }
     end
   end
 

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -35,6 +35,35 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
         end
       end
     end
+
+    context "when provided with link text and url params" do
+      let(:link_text) { 'Onwards!' }
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+      let(:link_url) { '/some/link' }
+
+      subject { govuk_link_to link_text, link_params }
+
+      before do
+        allow(self).to receive(:url_for).with(link_params).and_return link_url
+      end
+
+      it { is_expected.to have_tag('a', text: link_text, with: { href: link_url, class: 'govuk-link' }) }
+    end
+
+    context "when provided with url params and the block" do
+      let(:link_text) { 'Onwards!' }
+      let(:link_html) { tag.span(link_text) }
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+      let(:link_url) { '/some/link' }
+
+      subject { govuk_link_to(link_params) { link_html } }
+
+      before do
+        allow(self).to receive(:url_for).with(link_params).and_return link_url
+      end
+
+      it { is_expected.to have_tag('a', with: { href: link_url }) { with_tag(:span, text: link_text)} }
+    end
   end
 
   describe '#govuk_button_classes' do

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -37,6 +37,32 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     end
   end
 
+  describe '#govuk_button_classes' do
+    subject { govuk_button_classes(*args) }
+
+    describe "by default" do
+      let(:args) { [] }
+
+      specify "contains only 'govuk-button'" do
+        expect(subject).to eql(%w(govuk-button))
+      end
+    end
+
+    {
+      secondary: 'govuk-button--secondary',
+      warning:   'govuk-button--warning',
+      disabled:  'govuk-button--disabled',
+    }.each do |style, css_class|
+      describe "generating a #{style}-style button with '#{style}: true'" do
+        let(:args) { [style] }
+
+        specify %(contains 'govuk-button' and '#{css_class}') do
+          expect(subject).to match_array(['govuk-button', css_class])
+        end
+      end
+    end
+  end
+
   describe "#govuk_link_to" do
     let(:link_text) { 'Onwards!' }
     let(:link_url) { '/some/link' }
@@ -75,33 +101,104 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       let(:link_params) { { controller: :some_controller, action: :some_action } }
       let(:custom_class) { { class: "green" } }
 
-      subject { govuk_link_to(link_text, link_params, { class: "green" }) }
+      subject { govuk_link_to(link_text, link_params, { class: "green", no_underline: true }) }
 
-      it { is_expected.to have_tag('a', with: { href: link_url, class: "green" }, text: link_text) }
+      it { is_expected.to have_tag('a', with: { href: link_url, class: %w(green govuk-link--no-underline) }, text: link_text) }
     end
   end
 
-  describe '#govuk_button_classes' do
-    subject { govuk_button_classes(**kwargs) }
+  describe "#govuk_mail_to" do
+    let(:link_text) { 'Send a message' }
+    let(:link_html) { tag.span(link_text) }
+    let(:email_address) { 'barney@gumble.net' }
+    let(:mailto_address) { "mailto:" + email_address }
 
-    describe "by default" do
-      let(:kwargs) { {} }
+    context "when email address and link text are provided via args" do
+      subject { govuk_mail_to(email_address, link_text) }
 
-      specify "contains only 'govuk-link'" do
-        expect(subject).to eql(%w(govuk-button))
+      it { is_expected.to have_tag('a', text: link_text, with: { href: mailto_address, class: 'govuk-link' }) }
+
+      context "customising the GOV.UK link style" do
+        let(:custom_html_options) { { no_underline: true } }
+
+        subject { govuk_mail_to(email_address, link_text, custom_html_options) }
+
+        it { is_expected.to have_tag('a', with: { href: mailto_address, class: "govuk-link--no-underline" }, text: link_text) }
       end
     end
 
-    {
-      secondary: 'govuk-button--secondary',
-      warning:   'govuk-button--warning',
-      disabled:  'govuk-button--disabled',
-    }.each do |style, css_class|
-      describe "generating a #{style}-style button with '#{style}: true'" do
-        let(:kwargs) { { style => true } }
+    context "when the link text is provided via an block" do
+      subject { govuk_mail_to(email_address) { link_html } }
 
-        specify %(contains 'govuk-button' and '#{css_class}') do
-          expect(subject).to match_array(['govuk-button', css_class])
+      it { is_expected.to have_tag('a', with: { href: mailto_address }) { with_tag(:span, text: link_text) } }
+
+      context "customising the GOV.UK link style" do
+        let(:custom_html_options) { { text_colour: true } }
+
+        subject { govuk_mail_to(email_address, custom_html_options) { link_html } }
+
+        it { is_expected.to have_tag('a', with: { href: mailto_address, class: "govuk-link--text-colour" }) { with_tag(:span, text: link_text) } }
+      end
+    end
+
+    context "adding custom classes" do
+      let(:custom_class) { { class: "green" } }
+
+      subject { govuk_mail_to(email_address, link_text, { class: "green", no_underline: true }) }
+
+      it { is_expected.to have_tag('a', with: { href: mailto_address, class: %w(green govuk-link--no-underline) }, text: link_text) }
+    end
+  end
+
+  describe "#govuk_button_to" do
+    let(:button_text) { 'Do something' }
+    let(:button_url) { '/some/action' }
+    let(:button_params) { { controller: :some_controller, action: :some_action } }
+
+    before do
+      allow(self).to receive(:url_for).with(button_params).and_return(button_url)
+    end
+
+    context "when provided with button text and url params" do
+      subject { govuk_button_to(button_text, button_params) }
+
+      specify "renders a form with an input of type submit and the correct attributes" do
+        expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
+          with_tag("input", with: { type: "submit", class: "govuk-button" })
+        end
+      end
+    end
+
+    context "when provided with url params and a block" do
+      let(:button_html) { tag.span(button_text) }
+
+      subject { govuk_button_to(button_params) { button_html } }
+
+      specify "renders a form with an button of type submit and the correct attributes" do
+        expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
+          with_tag("button", with: { type: "submit", class: "govuk-button" })
+        end
+      end
+    end
+
+    context "customising the GOV.UK button style" do
+      let(:custom_button_options) { { secondary: true } }
+
+      subject { govuk_button_to(button_text, button_params, custom_button_options) }
+
+      specify "renders a form with an button that has the GOV.UK modifier classes" do
+        expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
+          with_tag("input", with: { type: "submit", class: %w(govuk-button govuk-button--secondary) })
+        end
+      end
+    end
+
+    context "adding custom classes" do
+      subject { govuk_button_to(button_text, button_params, { class: "yellow", disabled: true }) }
+
+      specify "renders a form with an button that has the custom classes" do
+        expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
+          with_tag("input", with: { type: "submit", class: %w(govuk-button yellow govuk-button--disabled) })
         end
       end
     end

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -10,10 +10,10 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
   let(:kwargs) { {} }
 
   describe '#govuk_link_classes' do
-    subject { govuk_link_classes(**kwargs) }
+    subject { govuk_link_classes(*args) }
 
     describe "by default" do
-      let(:kwargs) { {} }
+      let(:args) { [] }
 
       specify "contains only 'govuk-link'" do
         expect(subject).to eql(%w(govuk-link))
@@ -28,14 +28,16 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       no_underline:     'govuk-link--no-underline',
     }.each do |style, css_class|
       describe "generating a #{style}-style link with '#{style}: true'" do
-        let(:kwargs) { { style => true } }
+        let(:args) { [style] }
 
         specify %(contains 'govuk-link' and '#{css_class}') do
           expect(subject).to match_array(['govuk-link', css_class])
         end
       end
     end
+  end
 
+  describe "#govuk_link_to" do
     context "when provided with link text and url params" do
       let(:link_text) { 'Onwards!' }
       let(:link_params) { { controller: :some_controller, action: :some_action } }
@@ -62,7 +64,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
         allow(self).to receive(:url_for).with(link_params).and_return link_url
       end
 
-      it { is_expected.to have_tag('a', with: { href: link_url }) { with_tag(:span, text: link_text)} }
+      it { is_expected.to have_tag('a', with: { href: link_url }) { with_tag(:span, text: link_text) } }
     end
   end
 


### PR DESCRIPTION
Wrapping Rails' `#link_to`, `#mail_to` and `#button_to` helpers is difficult because of the internal implementation and the complications added by mixing keyword arguments in with the existing args. This difficulty is exacerbated by the change in [Ruby 3.0's separation of positional and keyword args](https://www.ruby-lang.org/en/news/2019/12/12/separation-of-positional-and-keyword-arguments-in-ruby-3-0/).

The above problems have been highlighted a couple of times (#66, #193) and have probably bitten other teams/developers more often.

This approach no longer attempts to wrap the methods directly but instead provides a easier way of building the GOV.UK-specific classes.

Instead of:

```slim
= govuk_link_to "some page", some_path, muted: true
```

We would now do:

```slim
= link_to "some page", some_path, class: govuk_link_classes(muted: true)
```

The `#govuk_link_classes` helper supports all the CSS options from govuk-frontend, including `:no_visited_state`, `:muted`, `:text_colour`, `:inverse`, and `:no_underline`.

The `#govuk_button_classes` helper supports `:warning`, `:disabled` and `:secondary` button styles.

Benefits of this approach:

* no complex code that juggles with arguments, optional arguments and different keyword arg handling across various versions of Ruby
* I actually understand it
* we can easily apply the styles to Rails' other link helpers, like #link_to_if, #link_to_unless and friends.


Fixes #193
