### PR TITLE
Links with url params

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -1,8 +1,27 @@
 module GovukLinkHelper
-  def govuk_link_to(*args, button: false, no_visited_state: false, muted: false, text_colour: false, inverse: false, no_underline: false, **kwargs, &block)
-    classes = build_classes(button, no_visited_state, muted, text_colour, inverse, no_underline)
+  EXTRA_OPTIONS = {
+    button: false,
+    no_visited_state: false,
+    muted: false,
+    text_colour: false,
+    inverse: false,
+    no_underline: false
+  }.freeze
 
-    link_to(*args, **inject_class(kwargs, class_name: classes), &block)
+  def govuk_link_to(name = nil, options = nil, extra_options = {}, &block)
+    extra_options = options if block_given?
+
+    html_options = extra_options&.slice!(*EXTRA_OPTIONS.keys) || {}
+    extra_options = EXTRA_OPTIONS.merge(extra_options || {})
+
+    classes = build_classes(*extra_options.values_at(*EXTRA_OPTIONS.keys))
+    html_options = inject_class(html_options, class_name: classes)
+
+    if block_given?
+      link_to(name, html_options, &block)
+    else
+      link_to(name, options, html_options)
+    end
   end
 
   def govuk_mail_to(*args, button: false, no_visited_state: false, muted: false, text_colour: false, inverse: false, no_underline: false, **kwargs, &block)
@@ -25,7 +44,7 @@ private
       text_colour_class(text_colour),
       inverse_class(inverse),
       no_underline_class(no_underline),
-    ]
+    ].compact.join(" ")
   end
 
   def inject_class(attributes, class_name:)

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -61,6 +61,35 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
         end
       end
     end
+
+    context "when provided with link text and url params" do
+      let(:link_text) { 'Onwards!' }
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+      let(:link_url) { '/some/link' }
+
+      subject { govuk_link_to link_text, link_params }
+
+      before do
+        allow(self).to receive(:url_for).with(link_params).and_return link_url
+      end
+
+      it { is_expected.to have_tag('a', text: link_text, with: { href: link_url, class: 'govuk-link' }) }
+    end
+
+    context "when provided with url params and the block" do
+      let(:link_text) { 'Onwards!' }
+      let(:link_html) { tag.span(link_text) }
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+      let(:link_url) { '/some/link' }
+
+      subject { govuk_link_to(link_params) { link_html } }
+
+      before do
+        allow(self).to receive(:url_for).with(link_params).and_return link_url
+      end
+
+      it { is_expected.to have_tag('a', with: { href: link_url }) { with_tag(:span, text: link_text)} }
+    end
   end
 
   describe '#govuk_mail_to' do


### PR DESCRIPTION
Please don't judge me, this is pretty ugly - but works!

It is also potentially possible to get it working with kwargs, but would require special handling when kwargs caputres url_options - so it would still require defining all the arguments and special handling in case we have been provided block. Honestly `link_to` signature is... amazing...

This fixes #193 and #66.