### PR TITLE
Allow the tag component to take blocks of HTML

### DIFF
--- a/app/components/govuk_component/tag_component.rb
+++ b/app/components/govuk_component/tag_component.rb
@@ -3,7 +3,7 @@ class GovukComponent::TagComponent < GovukComponent::Base
 
   COLOURS = %w(grey green turquoise blue red purple pink orange yellow).freeze
 
-  def initialize(text:, colour: nil, classes: [], html_attributes: {})
+  def initialize(text: nil, colour: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @text   = text
@@ -11,10 +11,14 @@ class GovukComponent::TagComponent < GovukComponent::Base
   end
 
   def call
-    tag.strong(@text, class: classes.append(colour_class), **html_attributes)
+    tag.strong(tag_content, class: classes.append(colour_class), **html_attributes)
   end
 
 private
+
+  def tag_content
+    @text || content || fail(ArgumentError, "no text or content")
+  end
 
   def default_classes
     %w(govuk-tag)

--- a/app/components/govuk_component/tag_component.rb
+++ b/app/components/govuk_component/tag_component.rb
@@ -1,17 +1,7 @@
 class GovukComponent::TagComponent < GovukComponent::Base
   attr_reader :text, :colour
 
-  COLOURS = %w(
-    grey
-    green
-    turquoise
-    blue
-    red
-    purple
-    pink
-    orange
-    yellow
-  ).freeze
+  COLOURS = %w(grey green turquoise blue red purple pink orange yellow).freeze
 
   def initialize(text:, colour: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)

--- a/spec/components/govuk_component/tag_component_spec.rb
+++ b/spec/components/govuk_component/tag_component_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(GovukComponent::TagComponent, type: :component) do
+  include_context 'helpers'
   include_context 'setup'
 
   let(:text) { 'Alert' }
@@ -12,6 +13,30 @@ RSpec.describe(GovukComponent::TagComponent, type: :component) do
 
     specify 'renders strong element with right class and text' do
       expect(rendered_component).to have_tag('strong', with: { class: component_css_class }, text: text)
+    end
+
+    context 'when content is supplied in a block' do
+      let(:custom_tag) { :mark }
+      let(:custom_text) { "highlighted text" }
+      let(:custom_class) { "orange" }
+
+      subject! do
+        render_inline(GovukComponent::TagComponent.new) do
+          helper.content_tag(custom_tag, custom_text, class: custom_class)
+        end
+      end
+
+      specify 'renders strong element with right class and text' do
+        expect(rendered_component).to have_tag('strong', with: { class: component_css_class }) do
+          with_tag(custom_tag, text: custom_text, with: { class: custom_class })
+        end
+      end
+    end
+
+    context 'when neither text or block content is supplied' do
+      specify 'raises an appropriate error' do
+        expect { render_inline(GovukComponent::TagComponent.new(colour: 'blue')) }.to raise_error(ArgumentError, /no text or content/)
+      end
     end
   end
 


### PR DESCRIPTION
- Put the colours constant back on one line
- Allow the tag component to take a block of HTML
