### PR TITLE
Rename phase banner phase_tag argument to tag

### DIFF
--- a/app/components/govuk_component/phase_banner_component.rb
+++ b/app/components/govuk_component/phase_banner_component.rb
@@ -1,10 +1,10 @@
 class GovukComponent::PhaseBannerComponent < GovukComponent::Base
   attr_reader :text, :phase_tag
 
-  def initialize(phase_tag: nil, text: nil, classes: [], html_attributes: {})
+  def initialize(tag: nil, text: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @phase_tag = phase_tag
+    @phase_tag = tag
     @text      = text
   end
 

--- a/spec/components/govuk_component/phase_banner_component_spec.rb
+++ b/spec/components/govuk_component/phase_banner_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component) do
 
   let(:phase) { 'Gamma' }
   let(:text) { 'This is an experimental service – be cautious' }
-  let(:kwargs) { { phase_tag: { text: phase }, text: text } }
+  let(:kwargs) { { tag: { text: phase }, text: text } }
 
   subject! { render_inline(GovukComponent::PhaseBannerComponent.new(**kwargs)) }
 
@@ -38,7 +38,7 @@ RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component) do
   end
 
   context "when a custom phase tag colour is provided" do
-    let(:kwargs) { { phase_tag: { text: phase, colour: 'orange' }, text: text } }
+    let(:kwargs) { { tag: { text: phase, colour: 'orange' }, text: text } }
 
     specify "the phase tag has the right colour class" do
       expect(rendered_component).to have_tag("strong", with: { class: "govuk-tag--orange" }, text: phase)

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -92,7 +92,7 @@ RSpec.describe(GovukComponentsHelper, type: 'helper') do
       helper_method: :govuk_phase_banner,
       klass: GovukComponent::PhaseBannerComponent,
       args: [],
-      kwargs: { phase_tag: { text: 'Phase Test' } },
+      kwargs: { tag: { text: 'Phase Test' } },
       css_matcher: %(.govuk-phase-banner)
     },
     {


### PR DESCRIPTION
Internally it's still called phase_tag so it doesn't clash with Rails' `#tag` helper
