### PR TITLE
Allow the back link component to take blocks

### DIFF
--- a/app/components/govuk_component/back_link_component.rb
+++ b/app/components/govuk_component/back_link_component.rb
@@ -1,7 +1,7 @@
 class GovukComponent::BackLinkComponent < GovukComponent::Base
   attr_reader :text, :href
 
-  def initialize(text:, href:, classes: nil, html_attributes: {})
+  def initialize(href:, text: nil, classes: nil, html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @text = text
@@ -9,10 +9,14 @@ class GovukComponent::BackLinkComponent < GovukComponent::Base
   end
 
   def call
-    link_to(text, href, class: classes, **html_attributes)
+    link_to(link_content, href, class: classes, **html_attributes)
   end
 
 private
+
+  def link_content
+    text || content || fail(ArgumentError, "no text or content")
+  end
 
   def default_classes
     %w(govuk-back-link)

--- a/spec/components/govuk_component/back_link_component_spec.rb
+++ b/spec/components/govuk_component/back_link_component_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
+  include_context 'helpers'
   include_context 'setup'
 
   let(:text) { 'Department for Education' }
@@ -12,6 +13,30 @@ RSpec.describe(GovukComponent::BackLinkComponent, type: :component) do
 
   specify 'renders a link with the right href and text' do
     expect(rendered_component).to have_tag('a', text: text, with: { href: href, class: component_css_class })
+  end
+
+  context 'when link text is provided via a block' do
+    let(:custom_text) { "Some text" }
+    let(:custom_tag) { :code }
+    subject! do
+      render_inline(GovukComponent::BackLinkComponent.new(href: href)) do
+        helper.content_tag(custom_tag, custom_text)
+      end
+    end
+
+    specify 'renders the component with custom tag and text' do
+      expect(rendered_component).to have_tag('a', with: { href: href, class: component_css_class }) do
+        with_tag(custom_tag, text: custom_text)
+      end
+    end
+  end
+
+  context "when neither text or a block is supplied" do
+    specify "raises an appropriate error" do
+      expect {
+        render_inline(GovukComponent::BackLinkComponent.new(href: href))
+      }.to raise_error(ArgumentError, "no text or content")
+    end
   end
 
   it_behaves_like 'a component that accepts custom classes'


### PR DESCRIPTION
This brings it in line with other components that allow any HTML to be passed in

Refs #202
