### PR TITLE
Allow inset text to be assigned a custom id

### DIFF
--- a/app/components/govuk_component/inset_text_component.rb
+++ b/app/components/govuk_component/inset_text_component.rb
@@ -1,21 +1,26 @@
 class GovukComponent::InsetTextComponent < GovukComponent::Base
-  attr_reader :text
+  attr_reader :text, :id
 
-  def initialize(text: nil, classes: [], html_attributes: {})
+  def initialize(text: nil, id: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @text = text
+    @id   = id
   end
 
   def call
-    tag.div(class: classes, **html_attributes) { content.presence || text }
+    tag.div(class: classes, id: id, **html_attributes) { inset_text_content }
   end
 
   def render?
-    text.present? || content.present?
+    inset_text_content.present?
   end
 
 private
+
+  def inset_text_content
+    content.presence || text
+  end
 
   def default_classes
     %w(govuk-inset-text)

--- a/spec/components/govuk_component/inset_text_component_spec.rb
+++ b/spec/components/govuk_component/inset_text_component_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe(GovukComponent::InsetTextComponent, type: :component) do
     before { render_inline(described_class.new(**kwargs)) }
 
     specify 'the text is rendered' do
-      expect(rendered_component).to have_tag('div', with: { class: 'govuk-inset-text' }, text: text)
+      expect(rendered_component).to have_tag('div', with: { class: component_css_class }, text: text)
     end
   end
 
@@ -24,7 +24,7 @@ RSpec.describe(GovukComponent::InsetTextComponent, type: :component) do
     before { render_inline(described_class.new(**kwargs)) { 'Something in a block' } }
 
     specify 'the block is rendered' do
-      expect(rendered_component).to have_tag('div', with: { class: 'govuk-inset-text' }, text: 'Something in a block')
+      expect(rendered_component).to have_tag('div', with: { class: component_css_class }, text: 'Something in a block')
     end
   end
 

--- a/spec/components/govuk_component/inset_text_component_spec.rb
+++ b/spec/components/govuk_component/inset_text_component_spec.rb
@@ -35,4 +35,13 @@ RSpec.describe(GovukComponent::InsetTextComponent, type: :component) do
       expect(rendered_component).to be_blank
     end
   end
+
+  context 'when a custom id is supplied' do
+    let(:custom_id) { 'abc123' }
+    before { render_inline(described_class.new(**kwargs.merge(id: custom_id))) }
+
+    specify 'the text is rendered with the custom id' do
+      expect(rendered_component).to have_tag('div', with: { id: custom_id, class: component_css_class }, text: text)
+    end
+  end
 end


### PR DESCRIPTION
- Allow inset text to be assigned a custom id
- Use the component_css_class variable throughout the inset text spec
