### PR TITLE
Add meta text and HTML settings to the footer

### DIFF
--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -1,6 +1,6 @@
 <%= tag.footer(class: classes, role: 'contentinfo', **html_attributes) do %>
-  <%= tag.div(class: container_classes) do %>
-    <div class="govuk-footer__meta">
+  <%= tag.div(class: container_classes, **container_html_attributes) do %>
+    <%= tag.div(class: meta_classes, **meta_html_attributes) do %>
       <% if meta.present? %>
         <%= meta %>
       <% else %>
@@ -35,6 +35,6 @@
           <%= tag.div(copyright, class: "govuk-footer__meta-item") %>
         </div>
       <% end %>
-    </div>
+    <% end %>
   <% end %>
 <% end %>

--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -1,5 +1,5 @@
 <%= tag.footer(class: classes, role: 'contentinfo', **html_attributes) do %>
-  <div class="govuk-width-container ">
+  <%= tag.div(class: container_classes) do %>
     <div class="govuk-footer__meta">
       <% if meta.present? %>
         <%= meta %>
@@ -36,5 +36,5 @@
         </div>
       <% end %>
     </div>
-  </div>
+  <% end %>
 <% end %>

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -1,17 +1,34 @@
 class GovukComponent::FooterComponent < GovukComponent::Base
-  renders_one :meta_content
+  renders_one :meta_html
   renders_one :meta
 
-  attr_reader :meta_items, :meta_items_title, :meta_licence, :copyright, :custom_container_classes
+  attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright, :custom_container_classes
 
-  def initialize(meta_items: {}, meta_items_title: "Support links", meta_licence: nil, classes: [], container_classes: [], html_attributes: {}, copyright_text: default_copright_text, copyright_url: default_copyright_url)
+  def initialize(
+    classes: [],
+    container_classes: [],
+    container_html_attributes: {},
+    copyright_text: default_copright_text,
+    copyright_url: default_copyright_url,
+    html_attributes: {},
+    meta_items: {},
+    meta_items_title: "Support links",
+    meta_licence: nil,
+    meta_text: nil,
+    meta_classes: [],
+    meta_html_attributes: {}
+  )
     super(classes: classes, html_attributes: html_attributes)
 
-    @meta_items               = build_meta_links(meta_items)
-    @meta_items_title         = meta_items_title
-    @meta_licence             = meta_licence
-    @copyright                = build_copyright(copyright_text, copyright_url)
-    @custom_container_classes = container_classes
+    @meta_text                        = meta_text
+    @meta_items                       = build_meta_links(meta_items)
+    @meta_items_title                 = meta_items_title
+    @meta_licence                     = meta_licence
+    @custom_meta_classes              = meta_classes
+    @custom_meta_html_attributes      = meta_html_attributes
+    @copyright                        = build_copyright(copyright_text, copyright_url)
+    @custom_container_classes         = container_classes
+    @custom_container_html_attributes = container_html_attributes
   end
 
 private
@@ -22,6 +39,22 @@ private
 
   def container_classes
     combine_classes(%w(govuk-width-container), custom_container_classes)
+  end
+
+  def meta_content
+    meta_html || meta_text
+  end
+
+  def meta_classes
+    %w(govuk-footer__meta).append(@custom_meta_classes)
+  end
+
+  def meta_html_attributes
+    @custom_meta_html_attributes
+  end
+
+  def container_html_attributes
+    @custom_container_html_attributes
   end
 
   def build_meta_links(links)

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -2,21 +2,26 @@ class GovukComponent::FooterComponent < GovukComponent::Base
   renders_one :meta_content
   renders_one :meta
 
-  attr_reader :meta_items, :meta_items_title, :meta_licence, :copyright
+  attr_reader :meta_items, :meta_items_title, :meta_licence, :copyright, :custom_container_classes
 
-  def initialize(meta_items: {}, meta_items_title: "Support links", meta_licence: nil, classes: [], html_attributes: {}, copyright_text: default_copright_text, copyright_url: default_copyright_url)
+  def initialize(meta_items: {}, meta_items_title: "Support links", meta_licence: nil, classes: [], container_classes: [], html_attributes: {}, copyright_text: default_copright_text, copyright_url: default_copyright_url)
     super(classes: classes, html_attributes: html_attributes)
 
-    @meta_items       = build_meta_links(meta_items)
-    @meta_items_title = meta_items_title
-    @meta_licence     = meta_licence
-    @copyright        = build_copyright(copyright_text, copyright_url)
+    @meta_items               = build_meta_links(meta_items)
+    @meta_items_title         = meta_items_title
+    @meta_licence             = meta_licence
+    @copyright                = build_copyright(copyright_text, copyright_url)
+    @custom_container_classes = container_classes
   end
 
 private
 
   def default_classes
     %w(govuk-footer)
+  end
+
+  def container_classes
+    combine_classes(%w(govuk-width-container), custom_container_classes)
   end
 
   def build_meta_links(links)

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -115,6 +115,16 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
       end
     end
 
+    describe "custom container HTML attributes" do
+      let(:custom_id) { "abc123" }
+      let(:custom_container_html_attributes) { { id: custom_id } }
+      let(:kwargs) { { container_html_attributes: custom_container_html_attributes } }
+
+      specify "should set the custom container classes" do
+        expect(rendered_component).to have_tag("div", with: { id: custom_id, class: "govuk-width-container" })
+      end
+    end
+
     describe "when custom meta_licence text is disabled" do
       let(:kwargs) { { meta_licence: false } }
       let(:licence_selector) { [selector, ".govuk-footer__licence-description"].join(" ") }
@@ -129,7 +139,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
 
       subject! do
         render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |footer|
-          footer.meta_content { custom_content }
+          footer.meta_html { custom_content }
         end
       end
 
@@ -145,9 +155,41 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
         end
       end
     end
+
+    describe "custom meta contents" do
+      describe "meta_text" do
+        let(:custom_text) { "Some meta text" }
+
+        subject! { render_inline(GovukComponent::FooterComponent.new(meta_text: custom_text, **kwargs)) }
+
+        specify "custom text is rendered" do
+          expect(rendered_component).to have_tag("div", with: { class: "govuk-footer__meta-item" }) do
+            with_text(Regexp.new(custom_text))
+          end
+        end
+      end
+
+      describe "meta_html" do
+        let(:custom_text) { "Some meta html" }
+        let(:custom_tag) { "span" }
+        let(:custom_html) { helper.content_tag(custom_tag, custom_text) }
+
+        subject! do
+          render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |component|
+            component.meta_html { custom_html }
+          end
+        end
+
+        specify "custom HTML is rendered" do
+          expect(rendered_component).to have_tag("div", with: { class: "govuk-footer__meta-item" }) do
+            with_tag(custom_tag, text: Regexp.new(custom_text))
+          end
+        end
+      end
+    end
   end
 
-  describe "overwriting all meta information with custom content" do
+  describe "overwriting all meta information entirely with custom content" do
     let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
 
     subject! do

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
       end
     end
 
-    describe "when custom meta_licence text is provided" do
+    describe "custom meta_licence text" do
       let(:licence_text) { "Permission is hereby granted, free of charge, to any person obtaining a copy of this software" }
       let(:kwargs) { { meta_licence: licence_text } }
       let(:licence_selector) { [selector, ".govuk-footer__licence-description"].join(" ") }
@@ -103,6 +103,15 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
             without_tag("svg")
           end
         end
+      end
+    end
+
+    describe "custom container classes" do
+      let(:custom_container_classes) { %w(polka dots) }
+      let(:kwargs) { { container_classes: custom_container_classes } }
+
+      specify "should set the custom container classes" do
+        expect(rendered_component).to have_tag("div", with: { class: custom_container_classes.append('govuk-width-container') })
       end
     end
 


### PR DESCRIPTION
  Allow custom meta and container attributes/classes to be set in the footer.

  Now both the footer's meta and container can have their classes and other HTML attributes customised.

  Additionally there's a `meta_text` argument that allows plain text to be rendered in the meta section. `meta_content` has been renamed to `meta_html` so to match the naming conventions used elsewhere.
