### PR TITLE
Make the breadcrumbs component more flexible

### DIFF
--- a/app/components/govuk_component/breadcrumbs_component.html.erb
+++ b/app/components/govuk_component/breadcrumbs_component.html.erb
@@ -1,14 +1,7 @@
 <%= tag.div(class: classes, **html_attributes) do %>
   <ol class="govuk-breadcrumbs__list">
-    <% @breadcrumbs.each do |text, link| %>
-
-      <% if link.present? %>
-        <li class="govuk-breadcrumbs__list-item">
-          <%= link_to(text, link, class: "govuk-breadcrumbs__link") %>
-        </li>
-      <% else %>
-        <%= tag.li(text, class: "govuk-breadcrumbs__list-item", aria: { current: "page" }) %>
-      <% end %>
+    <% @breadcrumbs.each do |link| %>
+      <%= link %>
     <% end %>
   </ol>
 <% end %>

--- a/app/components/govuk_component/breadcrumbs_component.rb
+++ b/app/components/govuk_component/breadcrumbs_component.rb
@@ -4,7 +4,7 @@ class GovukComponent::BreadcrumbsComponent < GovukComponent::Base
   def initialize(breadcrumbs:, hide_in_print: false, collapse_on_mobile: false, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @breadcrumbs        = breadcrumbs
+    @breadcrumbs        = build_list(breadcrumbs)
     @hide_in_print      = hide_in_print
     @collapse_on_mobile = collapse_on_mobile
   end
@@ -16,5 +16,28 @@ private
       classes << "govuk-!-display-none-print" if hide_in_print
       classes << "govuk-breadcrumbs--collapse-on-mobile" if collapse_on_mobile
     end
+  end
+
+  def build_list(breadcrumbs)
+    case breadcrumbs
+    when Array
+      breadcrumbs.map { |item| build_list_item(item) }
+    when Hash
+      breadcrumbs.map { |text, link| build_list_item(text, link) }
+    else
+      fail(ArgumentError, "breadcrumb must be an array or hash")
+    end
+  end
+
+  def build_list_item(text, link = nil)
+    if link.present?
+      list_item { link_to(text, link, class: "govuk-breadcrumbs__link") }
+    else
+      list_item(aria: { current: "page" }) { text }
+    end
+  end
+
+  def list_item(html_attributes = {}, &block)
+    tag.li(class: "govuk-breadcrumbs__list-item", **html_attributes, &block)
   end
 end

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -53,7 +53,7 @@ module GovukLinkHelper
 
   def govuk_button_to(name = nil, options = nil, extra_options = {}, &block)
     extra_options = options if block_given?
-    html_options = build_html_options(extra_options, button: true)
+    html_options = build_html_options(extra_options, style: :button)
 
     if block_given?
       button_to(name, html_options, &block)
@@ -62,21 +62,41 @@ module GovukLinkHelper
     end
   end
 
+  def govuk_breadcrumb_link_to(name = nil, options = nil, extra_options = {}, &block)
+    extra_options = options if block_given?
+    html_options = build_html_options(extra_options, style: :breadcrumb)
+
+    if block_given?
+      link_to(name, html_options, &block)
+    else
+      link_to(name, options, html_options)
+    end
+  end
+
 private
 
-  def build_html_options(provided_options, button: false)
-    styles = (button ? BUTTON_STYLES : LINK_STYLES)
+  def build_html_options(provided_options, style: :link)
+    styles = case style
+             when :link       then LINK_STYLES
+             when :button     then BUTTON_STYLES
+             else {}
+             end
 
     remaining_options = provided_options&.slice!(*styles.keys)
 
-    return {} unless (style_classes = build_style_classes(button, provided_options))
+    return {} unless (style_classes = build_style_classes(style, provided_options))
 
     inject_class(remaining_options, class_name: style_classes)
   end
 
-  def build_style_classes(button, provided_options)
+  def build_style_classes(style, provided_options)
     keys = *provided_options&.keys
-    button ? govuk_button_classes(*keys) : govuk_link_classes(*keys)
+
+    case style
+    when :link then govuk_link_classes(*keys)
+    when :button then govuk_button_classes(*keys)
+    when :breadcrumb then %w(govuk-breadcrumbs__link)
+    end
   end
 
   def inject_class(attributes, class_name:)

--- a/spec/components/govuk_component/breadcrumbs_component_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_component_spec.rb
@@ -26,6 +26,22 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
     end
   end
 
+  context 'when an array is provided instead of a hash' do
+    let(:breadcrumbs) { %w(one two three four five) }
+
+    specify 'renders the array items in the breadcrumbs list' do
+      expect(rendered_component).to have_tag('div', with: { class: component_css_class }) do
+        with_tag('ol', with: { class: 'govuk-breadcrumbs__list' }) do
+          with_tag('li', with: { class: 'govuk-breadcrumbs__list-item' }, count: breadcrumbs.size)
+
+          breadcrumbs.each do |bc|
+            with_tag('li', with: { class: 'govuk-breadcrumbs__list-item' }, text: bc)
+          end
+        end
+      end
+    end
+  end
+
   specify 'breadcrumbs links are correct' do
     breadcrumbs.reject { |_, path| path.nil? }.each do |name, path|
       expect(rendered_component).to have_tag('li > a', with: { class: 'govuk-breadcrumbs__link', href: path }, text: name)

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -203,4 +203,39 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       end
     end
   end
+
+  describe "#govuk_breadcrumb_link_to" do
+    let(:breadcrumb_text) { 'Grandparent' }
+    let(:breadcrumb_url) { '/several/levels/up' }
+
+    before do
+      allow(self).to receive(:url_for).with(breadcrumb_params).and_return(breadcrumb_url)
+    end
+
+    context "when provided with text and url params" do
+      let(:breadcrumb_params) { { controller: :some_controller, action: :some_action } }
+
+      subject { govuk_breadcrumb_link_to(breadcrumb_text, breadcrumb_params) }
+
+      it { is_expected.to have_tag('a', text: breadcrumb_text, with: { href: breadcrumb_url, class: 'govuk-breadcrumbs__link' }) }
+    end
+
+    context "when provided with url params and the block" do
+      let(:breadcrumb_html) { tag.span(breadcrumb_text) }
+      let(:breadcrumb_params) { { controller: :some_controller, action: :some_action } }
+
+      subject { govuk_breadcrumb_link_to(breadcrumb_params) { breadcrumb_html } }
+
+      it { is_expected.to have_tag('a', with: { href: breadcrumb_url }) { with_tag(:span, text: breadcrumb_text) } }
+    end
+
+    context "adding custom classes" do
+      let(:breadcrumb_params) { { controller: :some_controller, action: :some_action } }
+      let(:custom_class) { "emphatic" }
+
+      subject { govuk_breadcrumb_link_to(breadcrumb_text, breadcrumb_params, { class: custom_class }) }
+
+      it { is_expected.to have_tag('a', with: { href: breadcrumb_url, class: ['govuk-breadcrumbs__link', custom_class] }, text: breadcrumb_text) }
+    end
+  end
 end


### PR DESCRIPTION
- Allow breadcrumbs to take an array of content
- Add a `#govuk_breadcrumb_link_to` helper
