### PR TITLE
Rename header items to navigation items

### DIFF
--- a/app/components/govuk_component/header_component.html.erb
+++ b/app/components/govuk_component/header_component.html.erb
@@ -21,17 +21,17 @@
       <% end %>
     </div>
 
-    <% if service_name.present? || items.present? %>
+    <% if service_name.present? || navigation_items.present? %>
       <div class="govuk-header__content">
         <% if service_name.present? %>
           <%= link_to(service_name, service_url, class: %w(govuk-header__link govuk-header__link--service-name)) %>
         <% end %>
 
-        <% if items.any? %>
+        <% if navigation_items.any? %>
           <%= tag.button("Menu", type: "button", class: %w(govuk-header__menu-button govuk-js-header-toggle), aria: { controls: "navigation", label: menu_button_label }) %>
           <nav>
             <%= tag.ul(class: navigation_classes, id: "navigation", aria: { label: navigation_label }) do %>
-              <% items.each do |item| %>
+              <% navigation_items.each do |item| %>
                 <%= tag.li(class: item.classes.append(item.active_class), **item.html_attributes) do %>
                   <% if item.link? %>
                     <%= link_to(item.text, item.href, class: "govuk-header__link") %>

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::HeaderComponent < GovukComponent::Base
-  renders_many :items, "Item"
+  renders_many :navigation_items, "NavigationItem"
   renders_one :custom_logo
   renders_one :product_name, "ProductName"
 
@@ -52,7 +52,7 @@ private
     combine_classes(%w(govuk-header__container govuk-width-container), custom_container_classes)
   end
 
-  class Item < GovukComponent::Base
+  class NavigationItem < GovukComponent::Base
     attr_reader :text, :href, :active
 
     def initialize(text:, href: nil, active: false, classes: [], html_attributes: {})

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -156,12 +156,19 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
     context 'when navigation items are supplied' do
       let(:custom_classes) { %w(blue shiny) }
-      let(:items) do
+      let(:navigation_items) do
         [
           { text: 'Item 1', href: '/item-1' },
           { text: 'Item 2', href: '/item-2', active: true },
           { text: 'Item 3', href: '/item-3' }
         ]
+      end
+
+      subject! do
+        header_kwargs = kwargs.merge(navigation_classes: custom_classes)
+        render_inline(GovukComponent::HeaderComponent.new(**header_kwargs)) do |component|
+          navigation_items.each { |navigation_item| component.navigation_item(**navigation_item) }
+        end
       end
 
       specify 'nav element is rendered' do
@@ -170,7 +177,7 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
       specify 'nav contains the right number of items' do
         expect(rendered_component).to have_tag('nav') do
-          with_tag('a', with: { class: 'govuk-header__link' }, count: items.size)
+          with_tag('a', with: { class: 'govuk-header__link' }, count: navigation_items.size)
         end
       end
 
@@ -190,22 +197,15 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
       specify 'nav items have the right text and links' do
         expect(rendered_component).to have_tag('nav') do
-          items.each { |link| with_tag('a', with: { href: link.fetch(:href) }, text: link.fetch(:text)) }
+          navigation_items.each { |link| with_tag('a', with: { href: link.fetch(:href) }, text: link.fetch(:text)) }
         end
       end
 
       specify 'active nav item has active class' do
-        active_link = items.detect { |item| item[:active] }
+        active_link = navigation_items.detect { |item| item[:active] }
 
         expect(rendered_component).to have_tag('nav') do
           with_tag('li', text: active_link.fetch(:text), with: { class: 'govuk-header__navigation-item--active' }, count: 1)
-        end
-      end
-
-      subject! do
-        header_kwargs = kwargs.merge(navigation_classes: custom_classes)
-        render_inline(GovukComponent::HeaderComponent.new(**header_kwargs)) do |component|
-          items.each { |item| component.item(**item) }
         end
       end
 
@@ -225,7 +225,7 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
           subject! do
             render_inline(GovukComponent::HeaderComponent.new(**kwargs.merge(menu_button_label: custom_label))) do |component|
-              items.each { |item| component.item(**item) }
+              navigation_items.each { |item| component.navigation_item(**item) }
             end
           end
 
@@ -242,7 +242,7 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
         subject! do
           render_inline(GovukComponent::HeaderComponent.new(**kwargs.merge(navigation_label: custom_label))) do |component|
-            items.each { |item| component.item(**item) }
+            navigation_items.each { |item| component.navigation_item(**item) }
           end
         end
 
@@ -257,7 +257,7 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
   it_behaves_like 'a component that accepts custom HTML attributes'
 
   context 'slot arguments' do
-    let(:slot) { :item }
+    let(:slot) { :navigation_item }
     let(:content) { nil }
     let(:slot_kwargs) { { text: 'text', href: '/one/two/three', active: true } }
 


### PR DESCRIPTION
In the Nunjucks macros a single array of navigation objects is passed in. Here, we'd need to call the slot multiple times so `#navigation_item` makes more sense than `#navigation.` The individual components of the navigation menu in the Design System are referred to as items so I think this is the best compromise.
