### PR TITLE
Allow the notification banner to take a text arg

### DIFF
--- a/app/components/govuk_component/notification_banner_component.html.erb
+++ b/app/components/govuk_component/notification_banner_component.html.erb
@@ -9,6 +9,6 @@
       <%= heading %>
     <% end %>
 
-    <%= content %>
+    <%= content || text %>
   </div>
 <% end %>

--- a/app/components/govuk_component/notification_banner_component.html.erb
+++ b/app/components/govuk_component/notification_banner_component.html.erb
@@ -1,7 +1,7 @@
 <%= tag.div(class: classes, role: "region", aria: { labelledby: title_id }, data: data_params, **html_attributes) do %>
   <div class="govuk-notification-banner__header">
     <%= content_tag(title_tag, class: "govuk-notification-banner__title", id: title_id) do %>
-      <%= title %>
+      <%= title_content %>
     <% end %>
   </div>
   <div class="govuk-notification-banner__content">

--- a/app/components/govuk_component/notification_banner_component.html.erb
+++ b/app/components/govuk_component/notification_banner_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: classes, role: "region", aria: { labelledby: title_id }, data: data_params, **html_attributes) do %>
+<%= tag.div(class: classes, role: role, aria: { labelledby: title_id }, data: data_params, **html_attributes) do %>
   <div class="govuk-notification-banner__header">
     <%= content_tag(title_tag, class: "govuk-notification-banner__title", id: title_id) do %>
       <%= title_content %>

--- a/app/components/govuk_component/notification_banner_component.rb
+++ b/app/components/govuk_component/notification_banner_component.rb
@@ -1,15 +1,16 @@
 class GovukComponent::NotificationBannerComponent < GovukComponent::Base
-  attr_reader :title_text, :title_id, :text, :success, :title_heading_level, :disable_auto_focus
+  attr_reader :title_text, :title_id, :text, :success, :title_heading_level, :disable_auto_focus, :role
 
   renders_one :title_html
   renders_many :headings, "Heading"
 
-  def initialize(title_text: nil, text: nil, success: false, title_heading_level: 2, title_id: "govuk-notification-banner-title", disable_auto_focus: nil, classes: [], html_attributes: {})
+  def initialize(title_text: nil, text: nil, role: "region", success: false, title_heading_level: 2, title_id: "govuk-notification-banner-title", disable_auto_focus: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @title_text          = title_text
     @title_id            = title_id
     @text                = text
+    @role                = role
     @success             = success
     @title_heading_level = title_heading_level
     @disable_auto_focus  = disable_auto_focus

--- a/app/components/govuk_component/notification_banner_component.rb
+++ b/app/components/govuk_component/notification_banner_component.rb
@@ -1,12 +1,13 @@
 class GovukComponent::NotificationBannerComponent < GovukComponent::Base
-  attr_reader :title, :title_id, :text, :success, :title_heading_level, :disable_auto_focus
+  attr_reader :title_text, :title_id, :text, :success, :title_heading_level, :disable_auto_focus
 
+  renders_one :title_html
   renders_many :headings, "Heading"
 
-  def initialize(title:, text: nil, success: false, title_heading_level: 2, title_id: "govuk-notification-banner-title", disable_auto_focus: nil, classes: [], html_attributes: {})
+  def initialize(title_text: nil, text: nil, success: false, title_heading_level: 2, title_id: "govuk-notification-banner-title", disable_auto_focus: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @title               = title
+    @title_text          = title_text
     @title_id            = title_id
     @text                = text
     @success             = success
@@ -24,6 +25,10 @@ class GovukComponent::NotificationBannerComponent < GovukComponent::Base
 
   def success_class
     %(govuk-notification-banner--success) if success
+  end
+
+  def title_content
+    title_html || title_text
   end
 
   def title_tag

--- a/app/components/govuk_component/notification_banner_component.rb
+++ b/app/components/govuk_component/notification_banner_component.rb
@@ -1,20 +1,21 @@
 class GovukComponent::NotificationBannerComponent < GovukComponent::Base
-  attr_reader :title, :title_id, :success, :title_heading_level, :disable_auto_focus
+  attr_reader :title, :title_id, :text, :success, :title_heading_level, :disable_auto_focus
 
   renders_many :headings, "Heading"
 
-  def initialize(title:, success: false, title_heading_level: 2, title_id: "govuk-notification-banner-title", disable_auto_focus: nil, classes: [], html_attributes: {})
+  def initialize(title:, text: nil, success: false, title_heading_level: 2, title_id: "govuk-notification-banner-title", disable_auto_focus: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @title               = title
     @title_id            = title_id
+    @text                = text
     @success             = success
     @title_heading_level = title_heading_level
     @disable_auto_focus  = disable_auto_focus
   end
 
   def render?
-    headings.any? || content.present?
+    headings.any? || text.present? || content.present?
   end
 
   def classes

--- a/spec/components/govuk_component/notification_banner_component_spec.rb
+++ b/spec/components/govuk_component/notification_banner_component_spec.rb
@@ -17,25 +17,40 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'
 
-    specify 'headings are rendered with text or content' do
-      render_inline(described_class.new(**kwargs)) do |component|
-        component.heading(**slot_kwargs)
-        component.heading(text: 'More text here')
-        component.heading do
-          helper.tag.p('some special content')
+    context "when supplied with a block" do
+      subject! do
+        render_inline(described_class.new(**kwargs)) do |component|
+          component.heading(**slot_kwargs)
+          component.heading(text: 'More text here')
+          component.heading do
+            helper.tag.p('some special content')
+          end
         end
       end
 
-      expect(rendered_component).to have_tag('div', with: { class: 'govuk-notification-banner__content' }) do
-        with_tag('div', with: { class: 'govuk-notification-banner__heading' }, text: /some text/) do
-          with_tag('a', with: { class: 'govuk-notification-banner__link', href: '#look-at-me' }, text: 'With a link')
-        end
+      specify 'headings are rendered with content' do
+        expect(rendered_component).to have_tag('div', with: { class: 'govuk-notification-banner__content' }) do
+          with_tag('div', with: { class: 'govuk-notification-banner__heading' }, text: /some text/) do
+            with_tag('a', with: { class: 'govuk-notification-banner__link', href: '#look-at-me' }, text: 'With a link')
+          end
 
-        with_tag('div', with: { class: 'govuk-notification-banner__heading' }, text: 'More text here')
+          with_tag('div', with: { class: 'govuk-notification-banner__heading' }, text: 'More text here')
 
-        with_tag('div', with: { class: 'govuk-notification-banner__heading' }) do
-          with_tag('p', text: 'some special content')
+          with_tag('div', with: { class: 'govuk-notification-banner__heading' }) do
+            with_tag('p', text: 'some special content')
+          end
         end
+      end
+    end
+
+    context "when supplied with some text" do
+      let(:text) { "Some custom text" }
+      let(:kwargs) { { title: title, text: text } }
+
+      subject! { render_inline(described_class.new(**kwargs)) }
+
+      specify 'headings are rendered with text' do
+        expect(rendered_component).to have_tag('div', text: Regexp.new(text), with: { class: 'govuk-notification-banner__content' })
       end
     end
   end

--- a/spec/components/govuk_component/notification_banner_component_spec.rb
+++ b/spec/components/govuk_component/notification_banner_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
   let(:component_css_class) { 'govuk-notification-banner' }
   let(:title) { 'A notification banner' }
 
-  let(:kwargs) { { title: title } }
+  let(:kwargs) { { title_text: title } }
 
   describe 'slot arguments' do
     let(:slot) { :heading }
@@ -45,12 +45,30 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
 
     context "when supplied with some text" do
       let(:text) { "Some custom text" }
-      let(:kwargs) { { title: title, text: text } }
+      let(:kwargs) { { title_text: title, text: text } }
 
       subject! { render_inline(described_class.new(**kwargs)) }
 
       specify 'headings are rendered with text' do
         expect(rendered_component).to have_tag('div', text: Regexp.new(text), with: { class: 'govuk-notification-banner__content' })
+      end
+    end
+
+    describe 'generating a title with custom HTML' do
+      let(:custom_text) { "Fancy title" }
+      let(:custom_tag) { "span" }
+      let(:custom_html) { helper.content_tag(custom_tag, custom_text) }
+
+      subject! do
+        render_inline(described_class.new(text: "Something")) do |component|
+          component.title_html { custom_html }
+        end
+      end
+
+      specify "the custom HTML is rendered in the title" do
+        expect(rendered_component).to have_tag("h2", with: { class: "govuk-notification-banner__title" }) do
+          with_tag(custom_tag, text: custom_text)
+        end
       end
     end
   end
@@ -90,7 +108,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
 
     describe 'overriding the role' do
       let(:custom_role) { 'alert' }
-      let(:kwargs) { { title: title, html_attributes: { role: custom_role } } }
+      let(:kwargs) { { title_text: title, html_attributes: { role: custom_role } } }
 
       specify 'replaces the default role with the provided one' do
         expect(rendered_component).to have_tag('div', with: { class: 'govuk-notification-banner', role: custom_role })
@@ -116,7 +134,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
     end
 
     describe 'custom title heading levels' do
-      let(:kwargs) { { title: title, title_heading_level: 4 } }
+      let(:kwargs) { { title_text: title, title_heading_level: 4 } }
 
       specify 'the title has the specified heading level' do
         expect(rendered_component).to have_tag('div', with: { class: 'govuk-notification-banner__header' }) do
@@ -126,7 +144,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
     end
 
     describe 'custom title id' do
-      let(:kwargs) { { title: title, title_id: 'custom-id' } }
+      let(:kwargs) { { title_text: title, title_id: 'custom-id' } }
 
       specify 'the title has the specified id' do
         expect(rendered_component).to have_tag('div', with: { class: 'govuk-notification-banner__header' }) do
@@ -167,7 +185,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
     end
 
     context 'when disable_auto_focus is true' do
-      let(:kwargs) { { title: title, disable_auto_focus: true } }
+      let(:kwargs) { { title_text: title, disable_auto_focus: true } }
 
       specify 'auto focus is disabled' do
         expect(rendered_component).to have_tag('div', with: { class: 'govuk-notification-banner', 'data-disable-auto-focus' => 'true' })
@@ -175,7 +193,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
     end
 
     context 'when success is true' do
-      let(:kwargs) { { title: title, success: true } }
+      let(:kwargs) { { title_text: title, success: true } }
 
       specify 'success class is appended' do
         expect(rendered_component).to have_tag('div', with: { class: %w(govuk-notification-banner govuk-notification-banner--success) })

--- a/spec/components/govuk_component/notification_banner_component_spec.rb
+++ b/spec/components/govuk_component/notification_banner_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
   let(:component_css_class) { 'govuk-notification-banner' }
   let(:title) { 'A notification banner' }
 
-  let(:kwargs) { { title_text: title } }
+  let(:kwargs) { { title_text: title, text: "something" } }
 
   describe 'slot arguments' do
     let(:slot) { :heading }
@@ -70,6 +70,18 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
           with_tag(custom_tag, text: custom_text)
         end
       end
+    end
+  end
+
+  describe 'custom role' do
+    let(:custom_role) { "feed" }
+
+    subject! do
+      render_inline(described_class.new(**kwargs.merge(role: custom_role, text: "unnecessary")))
+    end
+
+    specify "renders a notification banner with the custom role" do
+      expect(rendered_component).to have_tag("div", with: { role: custom_role, class: component_css_class })
     end
   end
 

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -77,7 +77,7 @@ RSpec.describe(GovukComponentsHelper, type: 'helper') do
       helper_method: :govuk_notification_banner,
       klass: GovukComponent::NotificationBannerComponent,
       args: [],
-      kwargs: { title: 'Notification banner' },
+      kwargs: { title_text: 'Notification banner' },
       css_matcher: %(.govuk-notification-banner),
       block: Proc.new { |nb| nb.heading(text: "heading 1", link_text: "link 1", link_href: "/link-1") },
     },


### PR DESCRIPTION
It complements the content block in the usual fashion and is ignored if both text and a block are supplied.
