### PR TITLE
Bring the panel's functionality in line with the Nunjucks macros

### DIFF
--- a/app/components/govuk_component/panel_component.rb
+++ b/app/components/govuk_component/panel_component.rb
@@ -1,12 +1,12 @@
 class GovukComponent::PanelComponent < GovukComponent::Base
-  attr_reader :title, :body, :heading_level
+  attr_reader :title, :text, :heading_level
 
-  def initialize(title: nil, body: nil, heading_level: 1, classes: [], html_attributes: {})
+  def initialize(title: nil, text: nil, heading_level: 1, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @heading_level = heading_level
     @title         = title
-    @body          = body
+    @text          = text
   end
 
   def call
@@ -21,31 +21,29 @@ private
     %w(govuk-panel govuk-panel--confirmation)
   end
 
-  def display_title?
-    title.present?
-  end
-
-  def display_body?
-    body.present? || content.present?
-  end
-
-  def panel_title
-    content_tag(heading_tag, title, class: "govuk-panel__title") if display_title?
-  end
-
   def heading_tag
     "h#{heading_level}"
   end
 
+  def panel_content
+    content || text
+  end
+
+  def panel_title
+    return if title.blank?
+
+    content_tag(heading_tag, title, class: "govuk-panel__title")
+  end
+
   def panel_body
-    if display_body?
-      tag.div(class: "govuk-panel__body") do
-        content.presence || body
-      end
+    return if panel_content.blank?
+
+    tag.div(class: "govuk-panel__body") do
+      panel_content
     end
   end
 
   def render?
-    display_title? || display_body?
+    title.present? || panel_content.present?
   end
 end

--- a/app/components/govuk_component/panel_component.rb
+++ b/app/components/govuk_component/panel_component.rb
@@ -1,11 +1,13 @@
 class GovukComponent::PanelComponent < GovukComponent::Base
-  attr_reader :title, :text, :heading_level
+  attr_reader :title_text, :text, :heading_level
 
-  def initialize(title: nil, text: nil, heading_level: 1, classes: [], html_attributes: {})
+  renders_one :title_html
+
+  def initialize(title_text: nil, text: nil, heading_level: 1, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @heading_level = heading_level
-    @title         = title
+    @title_text    = title_text
     @text          = text
   end
 
@@ -27,6 +29,10 @@ private
 
   def panel_content
     content || text
+  end
+
+  def title
+    title_html || title_text
   end
 
   def panel_title

--- a/app/components/govuk_component/panel_component.rb
+++ b/app/components/govuk_component/panel_component.rb
@@ -1,18 +1,19 @@
 class GovukComponent::PanelComponent < GovukComponent::Base
-  attr_reader :title_text, :text, :heading_level
+  attr_reader :id, :title_text, :text, :heading_level
 
   renders_one :title_html
 
-  def initialize(title_text: nil, text: nil, heading_level: 1, classes: [], html_attributes: {})
+  def initialize(title_text: nil, text: nil, heading_level: 1, id: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @heading_level = heading_level
     @title_text    = title_text
     @text          = text
+    @id            = id
   end
 
   def call
-    tag.div(class: classes, **html_attributes) do
+    tag.div(id: id, class: classes, **html_attributes) do
       safe_join([panel_title, panel_body].compact)
     end
   end

--- a/app/components/govuk_component/panel_component.rb
+++ b/app/components/govuk_component/panel_component.rb
@@ -1,11 +1,12 @@
 class GovukComponent::PanelComponent < GovukComponent::Base
-  attr_reader :title, :body
+  attr_reader :title, :body, :heading_level
 
-  def initialize(title: nil, body: nil, classes: [], html_attributes: {})
+  def initialize(title: nil, body: nil, heading_level: 1, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @title = title
-    @body  = body
+    @heading_level = heading_level
+    @title         = title
+    @body          = body
   end
 
   def call
@@ -29,7 +30,11 @@ private
   end
 
   def panel_title
-    tag.h1(title, class: "govuk-panel__title") if display_title?
+    content_tag(heading_tag, title, class: "govuk-panel__title") if display_title?
+  end
+
+  def heading_tag
+    "h#{heading_level}"
   end
 
   def panel_body

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -33,6 +33,15 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
     end
   end
 
+  context 'with a custom heading level' do
+    let(:custom_heading_level) { 3 }
+    before { render_inline(described_class.new(**kwargs.merge(heading_level: custom_heading_level))) }
+
+    specify 'contains a panel with the title and no body' do
+      expect(rendered_component).to have_tag(%(h#{custom_heading_level}), with: { class: 'govuk-panel__title' }, text: title)
+    end
+  end
+
   context 'when no body is supplied' do
     before { render_inline(described_class.new(**kwargs.except(:body))) }
 

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -32,9 +32,19 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
     end
 
     specify "the custom HTMl is rendered" do
-      expect(rendered_component).to have_tag("div", with: { class: "govuk-panel" }) do
+      expect(rendered_component).to have_tag("div", with: { class: component_css_class }) do
         with_tag(custom_tag, text: custom_title_text)
       end
+    end
+  end
+
+  context 'when a custom id is supplied' do
+    let(:custom_id) { "fancy-id" }
+
+    before { render_inline(described_class.new(**kwargs.merge(id: custom_id))) }
+
+    specify 'renders the panel with the custom id' do
+      expect(rendered_component).to have_tag('div', with: { id: custom_id, class: component_css_class })
     end
   end
 

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -7,28 +7,28 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
   let(:component_css_class) { 'govuk-panel.govuk-panel--confirmation' }
 
   let(:title) { 'Springfield' }
-  let(:body) { 'A noble spirit embiggens the smallest man' }
-  let(:kwargs) { { title: title, body: body } }
+  let(:text) { 'A noble spirit embiggens the smallest man' }
+  let(:kwargs) { { title: title, text: text } }
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
 
-  specify 'contains a panel with the correct title and body text' do
+  specify 'contains a panel with the correct title and text' do
     render_inline(described_class.new(**kwargs))
 
     expect(rendered_component).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
       with_tag('h1', with: { class: 'govuk-panel__title' }, text: title)
-      with_tag('div', with: { class: 'govuk-panel__body' }, text: body)
+      with_tag('div', with: { class: 'govuk-panel__body' }, text: text)
     end
   end
 
   context 'when no title is supplied' do
     before { render_inline(described_class.new(**kwargs.except(:title))) }
 
-    specify 'contains a panel with no title and the body' do
+    specify 'contains a panel with no title and the text' do
       expect(rendered_component).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
         without_tag('h1', with: { class: 'govuk-panel__title' }, text: title)
-        with_tag('div', with: { class: 'govuk-panel__body' }, text: body)
+        with_tag('div', with: { class: 'govuk-panel__body' }, text: text)
       end
     end
   end
@@ -37,18 +37,18 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
     let(:custom_heading_level) { 3 }
     before { render_inline(described_class.new(**kwargs.merge(heading_level: custom_heading_level))) }
 
-    specify 'contains a panel with the title and no body' do
+    specify 'contains a panel with the title and no text' do
       expect(rendered_component).to have_tag(%(h#{custom_heading_level}), with: { class: 'govuk-panel__title' }, text: title)
     end
   end
 
-  context 'when no body is supplied' do
-    before { render_inline(described_class.new(**kwargs.except(:body))) }
+  context 'when no text is supplied' do
+    before { render_inline(described_class.new(**kwargs.except(:text))) }
 
-    specify 'contains a panel with the title and no body' do
+    specify 'contains a panel with the title and no text' do
       expect(rendered_component).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
         with_tag('h1', with: { class: 'govuk-panel__title' }, text: title)
-        without_tag('div', with: { class: 'govuk-panel__body' }, text: body)
+        without_tag('div', with: { class: 'govuk-panel__body' }, text: text)
       end
     end
   end

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -6,9 +6,9 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
 
   let(:component_css_class) { 'govuk-panel.govuk-panel--confirmation' }
 
-  let(:title) { 'Springfield' }
+  let(:title_text) { 'Springfield' }
   let(:text) { 'A noble spirit embiggens the smallest man' }
-  let(:kwargs) { { title: title, text: text } }
+  let(:kwargs) { { title_text: title_text, text: text } }
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
@@ -17,17 +17,33 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
     render_inline(described_class.new(**kwargs))
 
     expect(rendered_component).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
-      with_tag('h1', with: { class: 'govuk-panel__title' }, text: title)
+      with_tag('h1', with: { class: 'govuk-panel__title' }, text: title_text)
       with_tag('div', with: { class: 'govuk-panel__body' }, text: text)
     end
   end
 
+  context 'when title_html is provided instead of title_text' do
+    let(:custom_tag) { "h5" }
+    let(:custom_title_text) { "I'm a title" }
+    before do
+      render_inline(described_class.new(**kwargs.except(:title_text))) do |component|
+        component.title_html { helper.content_tag(custom_tag, custom_title_text) }
+      end
+    end
+
+    specify "the custom HTMl is rendered" do
+      expect(rendered_component).to have_tag("div", with: { class: "govuk-panel" }) do
+        with_tag(custom_tag, text: custom_title_text)
+      end
+    end
+  end
+
   context 'when no title is supplied' do
-    before { render_inline(described_class.new(**kwargs.except(:title))) }
+    before { render_inline(described_class.new(**kwargs.except(:title_text))) }
 
     specify 'contains a panel with no title and the text' do
       expect(rendered_component).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
-        without_tag('h1', with: { class: 'govuk-panel__title' }, text: title)
+        without_tag('h1', with: { class: 'govuk-panel__title' }, text: title_text)
         with_tag('div', with: { class: 'govuk-panel__body' }, text: text)
       end
     end
@@ -38,7 +54,7 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
     before { render_inline(described_class.new(**kwargs.merge(heading_level: custom_heading_level))) }
 
     specify 'contains a panel with the title and no text' do
-      expect(rendered_component).to have_tag(%(h#{custom_heading_level}), with: { class: 'govuk-panel__title' }, text: title)
+      expect(rendered_component).to have_tag(%(h#{custom_heading_level}), with: { class: 'govuk-panel__title' }, text: title_text)
     end
   end
 
@@ -47,18 +63,18 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
 
     specify 'contains a panel with the title and no text' do
       expect(rendered_component).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
-        with_tag('h1', with: { class: 'govuk-panel__title' }, text: title)
+        with_tag('h1', with: { class: 'govuk-panel__title' }, text: title_text)
         without_tag('div', with: { class: 'govuk-panel__body' }, text: text)
       end
     end
   end
 
   context 'when a block is supplied' do
-    before { render_inline(described_class.new(**kwargs.except(:title))) { helper.tag.div('Something in a block') } }
+    before { render_inline(described_class.new(**kwargs.except(:title_text))) { helper.tag.div('Something in a block') } }
 
     specify 'contains a panel with no title and the block' do
       expect(rendered_component).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--confirmation) }) do
-        without_tag('h1', with: { class: 'govuk-panel__title' }, text: title)
+        without_tag('h1', with: { class: 'govuk-panel__title' }, text: title_text)
         with_tag('div', with: { class: 'govuk-panel__body' }) do
           with_tag('div', text: 'Something in a block')
         end

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe(GovukComponentsHelper, type: 'helper') do
       helper_method: :govuk_panel,
       klass: GovukComponent::PanelComponent,
       args: [],
-      kwargs: { title: 'Panel title', text: 'Panel body' },
+      kwargs: { title_text: 'Panel title', text: 'Panel body' },
       css_matcher: %(.govuk-panel)
     },
     {

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -85,7 +85,7 @@ RSpec.describe(GovukComponentsHelper, type: 'helper') do
       helper_method: :govuk_panel,
       klass: GovukComponent::PanelComponent,
       args: [],
-      kwargs: { title: 'Panel title', body: 'Panel body' },
+      kwargs: { title: 'Panel title', text: 'Panel body' },
       css_matcher: %(.govuk-panel)
     },
     {


### PR DESCRIPTION
- Allow the panel's heading tag to be customised
- Rename panel body param to text
- Add support for custom HTML in panel titles
- Allow panels to be assigned a custom id
