### PR TITLE
Ensure notification banner role is 'alert' when successful

### DIFF
--- a/app/components/govuk_component/notification_banner_component.rb
+++ b/app/components/govuk_component/notification_banner_component.rb
@@ -20,24 +20,6 @@ class GovukComponent::NotificationBannerComponent < GovukComponent::Base
     headings.any? || text.present? || content.present?
   end
 
-  def classes
-    super.append(success_class).compact
-  end
-
-  def success_class
-    %(govuk-notification-banner--success) if success
-  end
-
-  def title_content
-    title_html || title_text
-  end
-
-  def title_tag
-    fail "title_heading_level must be a number between 1 and 6" unless title_heading_level.is_a?(Integer) && title_heading_level.in?(1..6)
-
-    "h#{title_heading_level}"
-  end
-
   class Heading < GovukComponent::Base
     attr_reader :text, :link_href, :link_text
 
@@ -76,6 +58,24 @@ private
 
   def data_params
     { "module" => "govuk-notification-banner", "disable-auto-focus" => disable_auto_focus }.compact
+  end
+
+  def classes
+    super.append(success_class).compact
+  end
+
+  def success_class
+    %(govuk-notification-banner--success) if success
+  end
+
+  def title_content
+    title_html || title_text
+  end
+
+  def title_tag
+    fail "title_heading_level must be a number between 1 and 6" unless title_heading_level.is_a?(Integer) && title_heading_level.in?(1..6)
+
+    "h#{title_heading_level}"
   end
 
   def default_role

--- a/app/components/govuk_component/notification_banner_component.rb
+++ b/app/components/govuk_component/notification_banner_component.rb
@@ -4,14 +4,14 @@ class GovukComponent::NotificationBannerComponent < GovukComponent::Base
   renders_one :title_html
   renders_many :headings, "Heading"
 
-  def initialize(title_text: nil, text: nil, role: "region", success: false, title_heading_level: 2, title_id: "govuk-notification-banner-title", disable_auto_focus: nil, classes: [], html_attributes: {})
+  def initialize(title_text: nil, text: nil, role: nil, success: false, title_heading_level: 2, title_id: "govuk-notification-banner-title", disable_auto_focus: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @title_text          = title_text
     @title_id            = title_id
     @text                = text
-    @role                = role
     @success             = success
+    @role                = role || default_role
     @title_heading_level = title_heading_level
     @disable_auto_focus  = disable_auto_focus
   end
@@ -76,5 +76,9 @@ private
 
   def data_params
     { "module" => "govuk-notification-banner", "disable-auto-focus" => disable_auto_focus }.compact
+  end
+
+  def default_role
+    success ? "alert" : "region"
   end
 end

--- a/spec/components/govuk_component/notification_banner_component_spec.rb
+++ b/spec/components/govuk_component/notification_banner_component_spec.rb
@@ -73,15 +73,33 @@ RSpec.describe(GovukComponent::NotificationBannerComponent, type: :component) do
     end
   end
 
-  describe 'custom role' do
-    let(:custom_role) { "feed" }
+  describe 'roles' do
+    context 'when default' do
+      subject! { render_inline(described_class.new(**kwargs)) }
 
-    subject! do
-      render_inline(described_class.new(**kwargs.merge(role: custom_role, text: "unnecessary")))
+      specify %(renders a notification banner with the default role 'region') do
+        expect(rendered_component).to have_tag("div", with: { role: 'region', class: component_css_class })
+      end
     end
 
-    specify "renders a notification banner with the custom role" do
-      expect(rendered_component).to have_tag("div", with: { role: custom_role, class: component_css_class })
+    context 'when succesful' do
+      subject! { render_inline(described_class.new(**kwargs.merge(success: true))) }
+
+      specify %(renders a notification banner with the default role 'alert') do
+        expect(rendered_component).to have_tag("div", with: { role: 'alert', class: component_css_class })
+      end
+    end
+
+    context 'when the role is overridden' do
+      let(:custom_role) { "feed" }
+
+      subject! do
+        render_inline(described_class.new(**kwargs.merge(role: custom_role, text: "unnecessary")))
+      end
+
+      specify "renders a notification banner with the custom role" do
+        expect(rendered_component).to have_tag("div", with: { role: custom_role, class: component_css_class })
+      end
     end
   end
 


### PR DESCRIPTION
- Set notification banner role to alert when success
- Make internal notification banner methods private

Fixes #217
