### PR TITLE
Bring tabs component in line with Nunjucks macro

### DIFF
--- a/app/components/govuk_component/tab_component.html.erb
+++ b/app/components/govuk_component/tab_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.div(class: classes, data: { module: 'govuk-tabs' }, **html_attributes) do %>
+<%= tag.div(id: id, class: classes, data: { module: 'govuk-tabs' }, **html_attributes) do %>
   <%= tag.h2(title, class: "govuk-tabs__title") %>
   <ul class="govuk-tabs__list">
     <% tabs.each.with_index do |tab, i| %>

--- a/app/components/govuk_component/tab_component.rb
+++ b/app/components/govuk_component/tab_component.rb
@@ -17,12 +17,13 @@ private
   end
 
   class Tab < GovukComponent::Base
-    attr_reader :label
+    attr_reader :label, :text
 
-    def initialize(label:, classes: [], html_attributes: {})
+    def initialize(label:, text: nil, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
       @label = label
+      @text  = text
     end
 
     def id(prefix: nil)
@@ -48,7 +49,7 @@ private
     end
 
     def call
-      content
+      content || text || fail(ArgumentError, "no text or content")
     end
   end
 end

--- a/app/components/govuk_component/tab_component.rb
+++ b/app/components/govuk_component/tab_component.rb
@@ -17,16 +17,16 @@ private
   end
 
   class Tab < GovukComponent::Base
-    attr_reader :title
+    attr_reader :label
 
-    def initialize(title:, classes: [], html_attributes: {})
+    def initialize(label:, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
-      @title = title
+      @label = label
     end
 
     def id(prefix: nil)
-      [prefix, title.parameterize].join
+      [prefix, label.parameterize].join
     end
 
     def hidden_class(i = nil)
@@ -40,7 +40,7 @@ private
     end
 
     def li_link
-      link_to(title, id(prefix: '#'), class: "govuk-tabs__tab")
+      link_to(label, id(prefix: '#'), class: "govuk-tabs__tab")
     end
 
     def default_classes

--- a/app/components/govuk_component/tab_component.rb
+++ b/app/components/govuk_component/tab_component.rb
@@ -1,12 +1,13 @@
 class GovukComponent::TabComponent < GovukComponent::Base
   renders_many :tabs, "Tab"
 
-  attr_reader :title
+  attr_reader :title, :id
 
-  def initialize(title:, classes: [], html_attributes: {})
+  def initialize(title:, id: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
     @title = title
+    @id    = id
   end
 
 private

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -91,6 +91,24 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
     end
   end
 
+  context 'when text is passed to a tab instead of a block' do
+    subject! do
+      render_inline(GovukComponent::TabComponent.new(**kwargs)) do |component|
+        tabs.each do |label, content|
+          component.tab(label: label, text: content)
+        end
+      end
+    end
+
+    specify 'each panel contains the right content' do
+      tabs.each do |title, content|
+        expect(rendered_component).to have_tag('div', with: { id: title.parameterize, class: 'govuk-tabs__panel' }) do
+          with_text(content)
+        end
+      end
+    end
+  end
+
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
 

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -16,7 +16,6 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
   end
 
   let(:kwargs) { { title: title } }
-  let(:title_matcher) { Regexp.new(title) }
 
   subject! do
     render_inline(GovukComponent::TabComponent.new(**kwargs)) do |component|
@@ -30,7 +29,7 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
 
   specify 'renders h2 element with right class and title' do
     expect(rendered_component).to have_tag(component_css_class_matcher) do
-      with_tag('h2', with: { class: 'govuk-tabs__title' }, text: title_matcher)
+      with_tag('h2', with: { class: 'govuk-tabs__title' }, text: title)
     end
   end
 

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
   include_context 'helpers'
 
   let(:title) { 'My favourite tabs' }
+  let(:label) { 'A tab' }
   let(:component_css_class) { 'govuk-tabs' }
 
   let(:tabs) do
@@ -19,8 +20,8 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
 
   subject! do
     render_inline(GovukComponent::TabComponent.new(**kwargs)) do |component|
-      tabs.each do |title, content|
-        component.tab(title: title) { content }
+      tabs.each do |label, content|
+        component.tab(label: label) { content }
       end
     end
   end
@@ -96,7 +97,7 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
   context 'slot arguments' do
     let(:slot) { :tab }
     let(:content) { -> { 'some swanky tab content' } }
-    let(:slot_kwargs) { { title: title } }
+    let(:slot_kwargs) { { label: label } }
 
     it_behaves_like 'a component with a slot that accepts custom classes'
     it_behaves_like 'a component with a slot that accepts custom html attributes'

--- a/spec/components/govuk_component/tab_component_spec.rb
+++ b/spec/components/govuk_component/tab_component_spec.rb
@@ -81,6 +81,15 @@ RSpec.describe(GovukComponent::TabComponent, type: :component) do
     expect(tab_link_hrefs).to eql(panel_ids)
   end
 
+  context 'when a custom id is provided' do
+    let(:custom_id) { 'abc-123' }
+    let(:kwargs) { { title: "Some tabs", id: custom_id } }
+
+    specify 'the tabs container has the specified id' do
+      expect(rendered_component).to have_tag('div', with: { id: custom_id, class: component_css_class })
+    end
+  end
+
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
 


### PR DESCRIPTION
This _mostly_ makes the tabs component work like the original Nunjucks macro.

The one difference is that because here we're generating the tab ids based on the ~~`title`~~ `label`, there's no real need for `idPrefix`.

Providing the user doesn't have two tabs with the same name, the ids will be unique.

## Changes

- Stop using matcher now we're using the tag helper
- Allow the tabs component to take a custom id
- Rename the tab slot's title to label
- Allow tab text to be set via arg as well as block
