### PR TITLE
Rewrite the summary list (with slots all the way down 🐢)

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -27,6 +27,10 @@ Style/StringConcatenation:
   Enabled: false
 Style/TrailingCommaInArrayLiteral:
   Enabled: false
+Style/TernaryParentheses:
+  Enabled: false
+Style/RedundantParentheses:
+  Enabled: false
 Naming/MethodParameterName:
   Enabled: false
 Style/PercentLiteralDelimiters:

--- a/app/components/govuk_component/summary_list_component.html.erb
+++ b/app/components/govuk_component/summary_list_component.html.erb
@@ -1,11 +1,5 @@
 <%= tag.dl(class: classes, **html_attributes) do %>
   <% rows.each do |row| %>
-    <%= tag.div(class: row.classes, **row.html_attributes) do %>
-      <%= tag.dt(row.key, class: "govuk-summary-list__key") %>
-      <%= tag.dd(row.value, class: "govuk-summary-list__value") %>
-      <% if any_row_has_actions? %>
-        <%= row.action %>
-      <% end %>
-    <% end %>
+    <%= row %>
   <% end %>
 <% end %>

--- a/app/components/govuk_component/summary_list_component.rb
+++ b/app/components/govuk_component/summary_list_component.rb
@@ -1,7 +1,7 @@
 class GovukComponent::SummaryListComponent < GovukComponent::Base
   attr_reader :borders
 
-  renders_many :rows, "Row"
+  renders_many :rows, GovukComponent::SummaryListComponent::RowComponent
 
   def initialize(borders: true, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
@@ -25,42 +25,5 @@ private
 
   def default_classes
     %w(govuk-summary-list)
-  end
-
-  class Row < GovukComponent::Base
-    attr_reader :key, :value, :href, :text, :visually_hidden_text, :action_classes, :action_attributes
-
-    def initialize(key:, value:, action: {}, classes: [], html_attributes: {})
-      super(classes: classes, html_attributes: html_attributes)
-
-      @key   = key
-      @value = value
-
-      if action.present?
-        @href                 = action[:href]
-        @text                 = action[:text] || "Change"
-        @visually_hidden_text = " #{action[:visually_hidden_text] || key.downcase}"
-        @action_classes       = action[:classes] || []
-        @action_attributes    = action[:html_attributes] || {}
-      end
-    end
-
-    def action
-      link_classes = govuk_link_classes.append(action_classes).flatten
-
-      tag.dd(class: "govuk-summary-list__actions") do
-        if href.present?
-          link_to(href, class: link_classes, **action_attributes) do
-            safe_join([text, tag.span(visually_hidden_text, class: "govuk-visually-hidden")])
-          end
-        end
-      end
-    end
-
-  private
-
-    def default_classes
-      %w(govuk-summary-list__row)
-    end
   end
 end

--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -13,11 +13,15 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
     link_classes = govuk_link_classes.append(classes).flatten
 
     link_to(href, class: link_classes, **html_attributes) do
-      safe_join([text, visually_hidden_span])
+      safe_join([action_text, visually_hidden_span])
     end
   end
 
 private
+
+  def action_text
+    content || text || fail(ArgumentError, "no text or content")
+  end
 
   def visually_hidden_span
     tag.span(visually_hidden_text, class: "govuk-visually-hidden") if visually_hidden_text.present?

--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -1,0 +1,25 @@
+class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Base
+  attr_reader :href, :text, :visually_hidden_text, :attributes, :classes
+
+  def initialize(href:, text: nil, visually_hidden_text: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+
+    @href                 = href
+    @text                 = text
+    @visually_hidden_text = visually_hidden_text
+  end
+
+  def call
+    link_classes = govuk_link_classes.append(classes).flatten
+
+    link_to(href, class: link_classes, **html_attributes) do
+      safe_join([text, visually_hidden_span])
+    end
+  end
+
+private
+
+  def visually_hidden_span
+    tag.span(visually_hidden_text, class: "govuk-visually-hidden") if visually_hidden_text.present?
+  end
+end

--- a/app/components/govuk_component/summary_list_component/key_component.rb
+++ b/app/components/govuk_component/summary_list_component/key_component.rb
@@ -1,0 +1,19 @@
+class GovukComponent::SummaryListComponent::KeyComponent < GovukComponent::Base
+  attr_reader :text
+
+  def initialize(text: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+
+    @text = text
+  end
+
+  def call
+    tag.dt(text, class: "govuk-summary-list__key")
+  end
+
+private
+
+  def key_content
+    content || text || fail(ArgumentError, "no text or content")
+  end
+end

--- a/app/components/govuk_component/summary_list_component/key_component.rb
+++ b/app/components/govuk_component/summary_list_component/key_component.rb
@@ -8,10 +8,14 @@ class GovukComponent::SummaryListComponent::KeyComponent < GovukComponent::Base
   end
 
   def call
-    tag.dt(text, class: "govuk-summary-list__key")
+    tag.dt(key_content, class: classes, **html_attributes)
   end
 
 private
+
+  def default_classes
+    %w(govuk-summary-list__key)
+  end
 
   def key_content
     content || text || fail(ArgumentError, "no text or content")

--- a/app/components/govuk_component/summary_list_component/row_component.rb
+++ b/app/components/govuk_component/summary_list_component/row_component.rb
@@ -1,36 +1,45 @@
 class GovukComponent::SummaryListComponent::RowComponent < GovukComponent::Base
-  attr_reader :key, :value, :href, :text, :visually_hidden_text, :action_classes, :action_attributes
+  attr_reader :href, :text, :visually_hidden_text, :actions_classes, :actions_attributes
 
-  def initialize(key:, value:, action: {}, classes: [], html_attributes: {})
+  renders_one :key, GovukComponent::SummaryListComponent::KeyComponent
+  renders_one :value, GovukComponent::SummaryListComponent::ValueComponent
+  renders_many :actions, GovukComponent::SummaryListComponent::ActionComponent
+
+  def initialize(classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
-
-    @key   = key
-    @value = value
-
-    if action.present?
-      @href                 = action[:href]
-      @text                 = action[:text] || "Change"
-      @visually_hidden_text = " #{action[:visually_hidden_text] || key.downcase}"
-      @action_classes       = action[:classes] || []
-      @action_attributes    = action[:html_attributes] || {}
-    end
   end
 
-  def action
-    link_classes = govuk_link_classes.append(action_classes).flatten
-
-    tag.dd(class: "govuk-summary-list__actions") do
-      if href.present?
-        link_to(href, class: link_classes, **action_attributes) do
-          safe_join([text, tag.span(visually_hidden_text, class: "govuk-visually-hidden")])
-        end
-      end
+  def call
+    tag.div(class: classes) do
+      safe_join([key, value, actions_content])
     end
   end
 
 private
 
+  def actions_content
+    return if actions.blank?
+
+    (actions.one?) ? single_action : actions_list
+  end
+
+  def single_action
+    tag.dd(class: actions_class) { safe_join(actions) }
+  end
+
+  def actions_list
+    tag.dd(class: actions_class) do
+      tag.ul(class: "govuk-summary-list__actions-list") do
+        safe_join(actions.map { |action| tag.li(action, class: "govuk-summary-list__actions-list-item") })
+      end
+    end
+  end
+
   def default_classes
     %w(govuk-summary-list__row)
+  end
+
+  def actions_class
+    "govuk-summary-list__actions"
   end
 end

--- a/app/components/govuk_component/summary_list_component/row_component.rb
+++ b/app/components/govuk_component/summary_list_component/row_component.rb
@@ -1,0 +1,36 @@
+class GovukComponent::SummaryListComponent::RowComponent < GovukComponent::Base
+  attr_reader :key, :value, :href, :text, :visually_hidden_text, :action_classes, :action_attributes
+
+  def initialize(key:, value:, action: {}, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+
+    @key   = key
+    @value = value
+
+    if action.present?
+      @href                 = action[:href]
+      @text                 = action[:text] || "Change"
+      @visually_hidden_text = " #{action[:visually_hidden_text] || key.downcase}"
+      @action_classes       = action[:classes] || []
+      @action_attributes    = action[:html_attributes] || {}
+    end
+  end
+
+  def action
+    link_classes = govuk_link_classes.append(action_classes).flatten
+
+    tag.dd(class: "govuk-summary-list__actions") do
+      if href.present?
+        link_to(href, class: link_classes, **action_attributes) do
+          safe_join([text, tag.span(visually_hidden_text, class: "govuk-visually-hidden")])
+        end
+      end
+    end
+  end
+
+private
+
+  def default_classes
+    %w(govuk-summary-list__row)
+  end
+end

--- a/app/components/govuk_component/summary_list_component/row_component.rb
+++ b/app/components/govuk_component/summary_list_component/row_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::SummaryListComponent::RowComponent < GovukComponent::Base
-  attr_reader :href, :text, :visually_hidden_text, :actions_classes, :actions_attributes
+  attr_reader :href, :text, :visually_hidden_text
 
   renders_one :key, GovukComponent::SummaryListComponent::KeyComponent
   renders_one :value, GovukComponent::SummaryListComponent::ValueComponent
@@ -10,7 +10,7 @@ class GovukComponent::SummaryListComponent::RowComponent < GovukComponent::Base
   end
 
   def call
-    tag.div(class: classes) do
+    tag.div(class: classes, **html_attributes) do
       safe_join([key, value, actions_content])
     end
   end

--- a/app/components/govuk_component/summary_list_component/value_component.rb
+++ b/app/components/govuk_component/summary_list_component/value_component.rb
@@ -1,0 +1,19 @@
+class GovukComponent::SummaryListComponent::ValueComponent < GovukComponent::Base
+  attr_reader :text
+
+  def initialize(text: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+
+    @text = text
+  end
+
+  def call
+    tag.dd(value_content, class: "govuk-summary-list__value")
+  end
+
+private
+
+  def value_content
+    content || text || fail(ArgumentError, "no text or content")
+  end
+end

--- a/app/components/govuk_component/summary_list_component/value_component.rb
+++ b/app/components/govuk_component/summary_list_component/value_component.rb
@@ -8,10 +8,14 @@ class GovukComponent::SummaryListComponent::ValueComponent < GovukComponent::Bas
   end
 
   def call
-    tag.dd(value_content, class: "govuk-summary-list__value")
+    tag.dd(value_content, class: classes, **html_attributes)
   end
 
 private
+
+  def default_classes
+    %w(govuk-summary-list__value)
+  end
 
   def value_content
     content || text || fail(ArgumentError, "no text or content")

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -147,3 +147,116 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
     end
   end
 end
+
+RSpec.describe(GovukComponent::SummaryListComponent::RowComponent, type: :component) do
+  include_context 'setup'
+
+  let(:component_css_class) { 'govuk-summary-list__row' }
+  let(:kwargs) { {} }
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
+end
+
+RSpec.describe(GovukComponent::SummaryListComponent::KeyComponent, type: :component) do
+  include_context 'helpers'
+  include_context 'setup'
+
+  let(:component_css_class) { 'govuk-summary-list__key' }
+  let(:kwargs) { { text: "Some key" } }
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
+
+  context "when there is no text or block" do
+    specify "raises an appropriate error" do
+      expect { render_inline(described_class.new) }.to raise_error(ArgumentError, "no text or content")
+    end
+  end
+
+  context "when there is a block of HTML" do
+    let(:custom_tag) { "h2" }
+    let(:custom_text) { "Fancy heading" }
+
+    subject! do
+      render_inline(described_class.new) do
+        helper.content_tag(custom_tag, custom_text)
+      end
+    end
+
+    specify "the custom HTML is rendered" do
+      expect(rendered_component).to have_tag("dt", with: { class: component_css_class }) do
+        with_tag(custom_tag, text: custom_text)
+      end
+    end
+  end
+end
+
+RSpec.describe(GovukComponent::SummaryListComponent::ValueComponent, type: :component) do
+  include_context 'setup'
+  include_context 'helpers'
+
+  let(:component_css_class) { 'govuk-summary-list__value' }
+  let(:kwargs) { { text: "Some value" } }
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
+
+  context "when there is no text or block" do
+    specify "raises an appropriate error" do
+      expect { render_inline(described_class.new) }.to raise_error(ArgumentError, "no text or content")
+    end
+  end
+
+  context "when there is a block of HTML" do
+    let(:custom_tag) { "h3" }
+    let(:custom_text) { "Fancier heading" }
+
+    subject! do
+      render_inline(described_class.new) do
+        helper.content_tag(custom_tag, custom_text)
+      end
+    end
+
+    specify "the custom HTML is rendered" do
+      expect(rendered_component).to have_tag("dd", with: { class: component_css_class }) do
+        with_tag(custom_tag, text: custom_text)
+      end
+    end
+  end
+end
+
+RSpec.describe(GovukComponent::SummaryListComponent::ActionComponent, type: :component) do
+  include_context 'setup'
+  include_context 'helpers'
+
+  let(:custom_path) { "/some/endpoint" }
+  let(:component_css_class) { 'govuk-link' }
+  let(:kwargs) { { href: custom_path, text: "Some value" } }
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
+
+  context "when there is no text or block" do
+    specify "raises an appropriate error" do
+      expect { render_inline(described_class.new(**kwargs.except(:text))) }.to raise_error(ArgumentError, "no text or content")
+    end
+  end
+
+  context "when there is a block of HTML" do
+    let(:custom_tag) { "span" }
+    let(:custom_text) { "Do a thing, now" }
+
+    subject! do
+      render_inline(described_class.new(href: custom_path)) do
+        helper.content_tag(custom_tag, custom_text)
+      end
+    end
+
+    specify "the custom HTML is rendered" do
+      expect(rendered_component).to have_tag("a", with: { class: component_css_class }) do
+        with_tag(custom_tag, text: custom_text)
+      end
+    end
+  end
+end

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -9,138 +9,141 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
   let(:action_link_text) { 'Something' }
   let(:action_link_href) { '#anchor' }
 
-  let(:rows) do
-    [
-      { key: 'One', value: 'The first item in the list' },
-      { key: 'Two', value: 'The second item in the list' },
-      { key: 'Three', value: 'The third item in the list', action: { href: action_link_href, text: action_link_text } },
-    ]
-  end
-
   let(:kwargs) { {} }
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
 
-  context 'slot arguments' do
-    let(:slot) { :row }
-    let(:content) { nil }
-    let(:slot_kwargs) { { key: 'key', value: 'value' } }
-
-    it_behaves_like 'a component with a slot that accepts custom classes'
-    it_behaves_like 'a component with a slot that accepts custom html attributes'
-
-    specify 'rows are rendered with keys, values and actions' do
-      render_inline(described_class.new) do |component|
-        component.row(key: 'this key', value: 'this value')
-        component.row(key: 'that key', value: 'that value', action: { href: '#change-this' })
-        component.row(
-          key: 'another key',
-          value: 'another value',
-          action: {
-            href: '#do-something',
-            text: 'Do',
-            visually_hidden_text: 'something',
-            classes: 'custom-class',
-            html_attributes: { 'data-tag' => 'some-data' },
-          },
+  subject! do
+    render_inline(described_class.new(**kwargs)) do |component|
+      component.row do |row|
+        helper.safe_join(
+          [
+            row.key(text: "Key"),
+            row.value(text: "Value"),
+            row.action(href: "/action", text: "Action"),
+          ]
         )
       end
+    end
+  end
 
-      expect(rendered_component).to have_tag('dl', with: { class: 'govuk-summary-list' }) do
-        with_tag('div', with: { class: 'govuk-summary-list__row' }) do
-          with_tag('dt', with: { class: 'govuk-summary-list__key' }, text: 'this key')
-          with_tag('dd', with: { class: 'govuk-summary-list__value' }, text: 'this value')
-          with_tag('dd', with: { class: 'govuk-summary-list__actions' })
+  specify "renders the summary list with the key, value and action" do
+    expect(rendered_component).to have_tag("dl", with: { class: component_css_class }) do
+      with_tag("div", with: { class: "govuk-summary-list__row" }) do
+        with_tag("dt", text: "Key", with: { class: "govuk-summary-list__key" })
+        with_tag("dd", text: "Value", with: { class: "govuk-summary-list__value" })
+        with_tag("dd", with: { class: "govuk-summary-list__actions" }) do
+          with_tag("a", with: { href: "/action" }, text: "Action")
         end
+      end
+    end
+  end
 
-        with_tag('div', with: { class: 'govuk-summary-list__row' }) do
-          with_tag('dt', with: { class: 'govuk-summary-list__key' }, text: 'this key')
-          with_tag('dd', with: { class: 'govuk-summary-list__value' }, text: 'this value')
-          with_tag('dd', with: { class: 'govuk-summary-list__actions' }) do
-            with_tag('a', with: { class: 'govuk-link', href: '#change-this' }, text: /Change/) do
-              with_tag('span', with: { class: 'govuk-visually-hidden' }, text: ' that key')
+  context "when there are multiple actions" do
+    subject! do
+      render_inline(described_class.new(**kwargs)) do |component|
+        component.row do |row|
+          helper.safe_join(
+            [
+              row.key(text: "Key"),
+              row.value(text: "Value"),
+              row.action(href: "/action-1", text: "First action"),
+              row.action(href: "/action-2", text: "Second action"),
+              row.action(href: "/action-3", text: "Third action"),
+            ]
+          )
+        end
+      end
+    end
+
+    specify "renders the summary list with the key, value and all the actions in an action list" do
+      expect(rendered_component).to have_tag("dl", with: { class: component_css_class }) do
+        with_tag("div", with: { class: "govuk-summary-list__row" }) do
+          with_tag("dt", text: "Key")
+          with_tag("dd", text: "Value")
+
+          with_tag("dd", with: { class: "govuk-summary-list__actions" }) do
+            with_tag("ul", with: { class: "govuk-summary-list__actions-list" }) do
+              { "/action-1" => "First action", "/action-2" => "Second action", "/action-3" => "Third action" }.each do |path, text|
+                with_tag("li", with: { class: "govuk-summary-list__actions-list-item" }) do
+                  with_tag("a", with: { href: path }, text: text)
+                end
+              end
             end
           end
         end
+      end
+    end
+  end
 
-        with_tag('div', with: { class: 'govuk-summary-list__row' }) do
-          with_tag('dt', with: { class: 'govuk-summary-list__key' }, text: 'another key')
-          with_tag('dd', with: { class: 'govuk-summary-list__value' }, text: 'another value')
-          with_tag('dd', with: { class: 'govuk-summary-list__actions' }) do
-            with_tag('a', with: { class: 'govuk-link custom-class', href: '#do-something', 'data-tag' => 'some-data' }, text: /Do/) do
-              with_tag('span', with: { class: 'govuk-visually-hidden' }, text: ' something')
-            end
-          end
+  context "when some rows don't have actions" do
+    subject! do
+      render_inline(described_class.new(**kwargs)) do |component|
+        component.row(classes: "with-actions") do |row|
+          helper.safe_join(
+            [row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/action", text: "Action")]
+          )
+        end
+
+        component.row(classes: "without-actions") do |row|
+          helper.safe_join(
+            [row.key(text: "Key"), row.value(text: "Value")]
+          )
+        end
+      end
+    end
+
+    specify "renders actions for the rows that do" do
+      expect(rendered_component).to have_tag("dl", with: { class: component_css_class }) do
+        with_tag("div", with: { class: %(with-actions govuk-summary-list__row) }) do
+          with_tag("dd", with: { class: "govuk-summary-list__actions" })
+        end
+      end
+    end
+
+    specify "doesn't render actions on rows that don't" do
+      expect(rendered_component).to have_tag("dl", with: { class: component_css_class }) do
+        with_tag("div", with: { class: %(without-actions govuk-summary-list__row) }) do
+          without_tag("dd", with: { class: "govuk-summary-list__actions" })
         end
       end
     end
   end
 
-  describe 'rendering a summary list with rows' do
-    before do
+  context "when there is visually hidden text" do
+    subject! do
       render_inline(described_class.new(**kwargs)) do |component|
-        rows.each { |row| component.row(**row) }
+        component.row(classes: "with-visually-hidden-text") do |row|
+          helper.safe_join(
+            [row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/action", text: "Action", visually_hidden_text: "visually hidden")]
+          )
+        end
+
+        component.row(classes: "without-visually-hidden-text") do |row|
+          helper.safe_join(
+            [row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/action", text: "Action")]
+          )
+        end
       end
     end
 
-    specify 'renders the summary list' do
-      expect(rendered_component).to have_tag('dl', with: { class: 'govuk-summary-list' })
-    end
-
-    context 'when borders is false' do
-      let(:kwargs) { { borders: false } }
-
-      specify 'no borders class is appended' do
-        expect(rendered_component).to have_tag('dl', with: { class: 'govuk-summary-list govuk-summary-list--no-border' })
-      end
-    end
-
-    specify 'renders the correct number of rows' do
-      expect(rendered_component).to have_tag('div', with: { class: 'govuk-summary-list__row' }, count: rows.size)
-    end
-
-    specify 'renders the correct content in the rows' do
-      expect(rendered_component).to have_tag('dl', with: { class: 'govuk-summary-list' }) do
-        rows.each do |row|
-          with_tag('div', with: { class: 'govuk-summary-list__row' }) do
-            with_tag('dt', with: { class: 'govuk-summary-list__key' }, text: row[:key])
-            with_tag('dd', with: { class: 'govuk-summary-list__value' }, text: row[:value])
+    specify "renders a span when visually hidden text is present" do
+      expect(rendered_component).to have_tag("dl", with: { class: component_css_class }) do
+        with_tag("div", with: { class: %(with-visually-hidden-text govuk-summary-list__row) }) do
+          with_tag("dd", with: { class: "govuk-summary-list__actions" }) do
+            with_tag("a.govuk-link > span", with: { class: "govuk-visually-hidden" })
           end
         end
       end
     end
-  end
 
-  context 'when no actions are present' do
-    before do
-      render_inline(described_class.new(**kwargs)) do |component|
-        rows.reject { |row| row.key?(:action) }.each { |row| component.row(**row) }
+    specify "renders no span when there's no visually hidden text" do
+      expect(rendered_component).to have_tag("dl", with: { class: component_css_class }) do
+        with_tag("div", with: { class: %(without-visually-hidden-text govuk-summary-list__row) }) do
+          without_tag("span", with: { class: "govuk-visually-hidden" })
+        end
       end
-    end
-
-    specify 'actions column is not present' do
-      expect(rendered_component).not_to have_tag('dd', with: { class: 'govuk-summary-list__actions' })
-    end
-  end
-
-  context 'when an action is nil' do
-    let(:rows) do
-      [
-        { key: 'One', value: 'First' },
-        { key: 'Two', value: 'Second', action: nil }
-      ]
-    end
-
-    before do
-      render_inline(described_class.new(**kwargs)) do |component|
-        rows.each { |row| component.row(**row) }
-      end
-    end
-
-    specify 'renders the summary list without an actions column' do
-      expect(rendered_component).to have_tag('dl', with: { class: 'govuk-summary-list' })
-      expect(rendered_component).not_to have_tag('dd', with: { class: 'govuk-summary-list__actions' })
     end
   end
 end


### PR DESCRIPTION
Summary list rows are too flexible for regular arguments, because:

* key can be set with either text or HTML
* value can be set with either text or HTML
* there can be multiple actions
* each action can have its text set with text or HTML
* keys, values and actions all accept custom classes and HTML attributes

Multi-level slots are the only way to achieve the above requirements without making the arguments incredibly complicated.