### PR TITLE
Add 'govuk-heading-m' to cookie banner message h2

### DIFF
--- a/app/components/govuk_component/cookie_banner_component/message_component.rb
+++ b/app/components/govuk_component/cookie_banner_component/message_component.rb
@@ -30,7 +30,7 @@ private
   end
 
   def heading_element
-    tag.h2(heading_content, class: "govuk-cookie-banner__heading")
+    tag.h2(heading_content, class: %w(govuk-cookie-banner__heading govuk-heading-m))
   end
 
   def heading_content

--- a/spec/components/govuk_component/cookie_banner_component_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_component_spec.rb
@@ -51,7 +51,7 @@ RSpec.describe(GovukComponent::CookieBannerComponent, type: :component) do
 
     specify "renders the message heading" do
       expect(rendered_component).to have_tag(message_selector) do
-        with_tag("h2", text: custom_heading_text)
+        with_tag("h2", text: custom_heading_text, with: { class: %w(govuk-cookie-banner__heading govuk-heading-m) })
       end
     end
 
@@ -133,7 +133,7 @@ RSpec.describe(GovukComponent::CookieBannerComponent::MessageComponent, type: :c
 
     specify "the custom heading HTML is rendered" do
       expect(rendered_component).to have_tag("div", with: { class: component_css_class, role: custom_role }) do
-        with_tag("h2", class: "govuk-cookie-banner__heading") do
+        with_tag("h2", class: %w(govuk-cookie-banner__heading govuk-heading-m)) do
           with_tag(custom_heading_tag, text: custom_heading_text)
         end
       end


### PR DESCRIPTION
It appears this class was lost during the v2.0.0 upgrade.

Fixes #226
