### PR TITLE
Don't error when summary list value is empty

### DIFF
--- a/app/components/govuk_component/summary_list_component/value_component.rb
+++ b/app/components/govuk_component/summary_list_component/value_component.rb
@@ -18,6 +18,6 @@ private
   end
 
   def value_content
-    content || text || fail(ArgumentError, "no text or content")
+    content || text || ""
   end
 end

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -218,8 +218,10 @@ RSpec.describe(GovukComponent::SummaryListComponent::ValueComponent, type: :comp
   it_behaves_like 'a component that accepts custom HTML attributes'
 
   context "when there is no text or block" do
-    specify "raises an appropriate error" do
-      expect { render_inline(described_class.new) }.to raise_error(ArgumentError, "no text or content")
+    subject! { render_inline(described_class.new) }
+
+    specify "renders an empty dd element" do
+      expect(rendered_component).to have_tag("dd", with: { class: "govuk-summary-list__value" }, text: "")
     end
   end
 


### PR DESCRIPTION
Some services might want to display the row in the summary list despite it having no content.
