### PR TITLE
Make cookie banner heading not required

### DIFF
--- a/app/components/govuk_component/cookie_banner_component/message_component.rb
+++ b/app/components/govuk_component/cookie_banner_component/message_component.rb
@@ -31,11 +31,13 @@ private
   end
 
   def heading_element
+    return if heading_content.blank?
+
     tag.h2(heading_content, class: %w(govuk-cookie-banner__heading govuk-heading-m))
   end
 
   def heading_content
-    heading_html || heading_text || fail(ArgumentError, "no heading_text or heading_html")
+    heading_html || heading_text
   end
 
   def message_element

--- a/spec/components/govuk_component/cookie_banner_component_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_component_spec.rb
@@ -90,12 +90,6 @@ RSpec.describe(GovukComponent::CookieBannerComponent::MessageComponent, type: :c
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
 
-  context "when there is no heading_text or heading_html" do
-    specify "raises an appropriate error" do
-      expect { render_inline(described_class.new(**kwargs.except(:heading_text))) }.to raise_error(ArgumentError, "no heading_text or heading_html")
-    end
-  end
-
   context "when there is no text or block" do
     specify "raises an appropriate error" do
       expect { render_inline(described_class.new(**kwargs.except(:text))) }.to raise_error(ArgumentError, "no text or content")


### PR DESCRIPTION
It's not required by the Nunjucks macros and shouldn't be here either.

Fixes #233
