### PR TITLE
Move cookie banner actions outside of grid-row

### DIFF
--- a/app/components/govuk_component/cookie_banner_component/message_component.rb
+++ b/app/components/govuk_component/cookie_banner_component/message_component.rb
@@ -15,12 +15,12 @@ class GovukComponent::CookieBannerComponent::MessageComponent < GovukComponent::
 
   def call
     tag.div(class: classes, role: role, hidden: hidden, **html_attributes) do
-      tag.div(class: "govuk-grid-row") do
-        safe_join([
-          tag.div(class: "govuk-grid-column-two-thirds") { safe_join([heading_element, message_element]) },
-          actions_element
-        ])
-      end
+      safe_join([
+        tag.div(class: "govuk-grid-row") do
+          tag.div(class: "govuk-grid-column-two-thirds") { safe_join([heading_element, message_element]) }
+        end,
+        actions_element
+      ])
     end
   end
 

--- a/spec/components/govuk_component/cookie_banner_component_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_component_spec.rb
@@ -70,7 +70,7 @@ RSpec.describe(GovukComponent::CookieBannerComponent, type: :component) do
     end
 
     specify "renders the actions" do
-      expect(rendered_component).to have_tag(".govuk-cookie-banner > .govuk-cookie-banner__message > .govuk-grid-row > div.govuk-button-group") do
+      expect(rendered_component).to have_tag(".govuk-cookie-banner > .govuk-cookie-banner__message > div.govuk-button-group") do
         with_tag("button", count: 1)
         with_tag("a", count: 1)
       end


### PR DESCRIPTION
They were incorrectly-placed in #230 and should've been another level out 🤦
