### PR TITLE
Move navigation entry generation to call method

### DIFF
--- a/app/components/govuk_component/header_component.html.erb
+++ b/app/components/govuk_component/header_component.html.erb
@@ -33,11 +33,7 @@
             <%= tag.ul(class: navigation_classes, id: "navigation", aria: { label: navigation_label }) do %>
               <% navigation_items.each do |item| %>
                 <%= tag.li(class: item.classes.append(item.active_class), **item.html_attributes) do %>
-                  <% if item.link? %>
-                    <%= link_to(item.text, item.href, class: "govuk-header__link") %>
-                  <% else %>
-                    <%= item.text %>
-                  <% end %>
+                  <%= item %>
                 <% end %>
               <% end %>
             <% end %>

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -75,6 +75,14 @@ private
       href.present?
     end
 
+    def call
+      if link?
+        link_to(text, href, class: "govuk-header__link")
+      else
+        text
+      end
+    end
+
   private
 
     def default_classes


### PR DESCRIPTION
This makes the navigation entries render from actual templates without throwing a 'no template' error. Seems to work either way in the tests.
