### PR TITLE
Register the table component with component helper

### DIFF
--- a/app/helpers/govuk_components_helper.rb
+++ b/app/helpers/govuk_components_helper.rb
@@ -13,6 +13,7 @@ module GovukComponentsHelper
     govuk_phase_banner: 'GovukComponent::PhaseBannerComponent',
     govuk_start_button: 'GovukComponent::StartButtonComponent',
     govuk_summary_list: 'GovukComponent::SummaryListComponent',
+    govuk_table: 'GovukComponent::TableComponent',
     govuk_tabs: 'GovukComponent::TabComponent',
     govuk_tag: 'GovukComponent::TagComponent',
     govuk_warning_text: 'GovukComponent::WarningTextComponent',

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -110,6 +110,13 @@ RSpec.describe(GovukComponentsHelper, type: 'helper') do
       css_matcher: %(.govuk-summary-list)
     },
     {
+      helper_method: :govuk_table,
+      klass: GovukComponent::TableComponent,
+      args: [],
+      kwargs: { caption: 'Table', rows: [%w(a b c), %w(d e f)] },
+      css_matcher: %(.govuk-table)
+    },
+    {
       helper_method: :govuk_tabs,
       klass: GovukComponent::TabComponent,
       args: [],


### PR DESCRIPTION
This will allow it to be called via `#govuk_table` rather than long `render GovukComponent...` syntax
