### PR TITLE
Fix breadcrumb text entries when key is symbol

### DIFF
--- a/app/components/govuk_component/breadcrumbs_component.rb
+++ b/app/components/govuk_component/breadcrumbs_component.rb
@@ -33,7 +33,7 @@ private
     if link.present?
       list_item { link_to(text, link, class: "govuk-breadcrumbs__link") }
     else
-      list_item(aria: { current: "page" }) { text }
+      list_item(aria: { current: "page" }) { text.to_s }
     end
   end
 

--- a/spec/dummy/app/views/demos/examples/_breadcrumbs.html.erb
+++ b/spec/dummy/app/views/demos/examples/_breadcrumbs.html.erb
@@ -1,12 +1,17 @@
 <%= example_heading('Breadcrumbs') %>
 
+<p class="govuk-inset-text">
+  To render the current level as text instead of a link you can pass either
+  <code>nil</code> or an empty string.
+</p>
+
 <%= render "shared/example",
   title: 'Breadcrumbs',
   example: <<~BREADCRUMBS
     render GovukComponent::BreadcrumbsComponent.new(breadcrumbs: {
       'Level one': '/level-one/',
       'Level two': '/level-one/level-two/',
-      'Level three': '/level-one/level-two/level-three'
+      'Level three': nil
     })
   BREADCRUMBS
 %>


### PR DESCRIPTION
When breadcrumb keys (the text) are symbols and there is no link, the rendering is broken because of the way `ActiveView::Helpers::CaptureHelper` works.

Now we're calling `#to_s` on the link text to ensure it renders. Also added a line to the documentation explaining that an empty string can be used here too.

Coincidentally this is caused by the same issue described in #249 raised earlier today.

Fixes #250
