### PR TITLE
Allow links with different HTTP method in header

### DIFF
--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -53,14 +53,15 @@ private
   end
 
   class NavigationItem < GovukComponent::Base
-    attr_reader :text, :href, :active
+    attr_reader :text, :href, :options, :active
 
-    def initialize(text:, href: nil, active: false, classes: [], html_attributes: {})
+    def initialize(text:, href: nil, options: {}, active: false, classes: [], html_attributes: {})
       super(classes: classes, html_attributes: html_attributes)
 
-      @text   = text
-      @href   = href
-      @active = active
+      @text    = text
+      @href    = href
+      @options = options
+      @active  = active
     end
 
     def active?
@@ -77,7 +78,7 @@ private
 
     def call
       if link?
-        link_to(text, href, class: "govuk-header__link")
+        link_to(text, href, **options, class: "govuk-header__link")
       else
         text
       end

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -157,7 +157,8 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
         [
           { text: 'Item 1', href: '/item-1' },
           { text: 'Item 2', href: '/item-2', active: true },
-          { text: 'Item 3', href: '/item-3' }
+          { text: 'Item 3', href: '/item-3' },
+          { text: 'Item 4', href: '/item-4', options: { method: :delete } }
         ]
       end
 
@@ -194,7 +195,13 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
       specify 'nav items have the right text and links' do
         expect(rendered_component).to have_tag('nav') do
-          navigation_items.each { |link| with_tag('a', with: { href: link.fetch(:href) }, text: link.fetch(:text)) }
+          navigation_items.each do |link|
+            if link.key?(:options)
+              with_tag('a', with: { href: link.fetch(:href), "data-method": link.dig(:options, :method) }, text: link.fetch(:text))
+            else
+              with_tag('a', with: { href: link.fetch(:href) }, text: link.fetch(:text))
+            end
+          end
         end
       end
 


### PR DESCRIPTION
In order to logout, Devise uses HTTP delete endpoints, so if you want to have a nav item to logout, this allows you to do that