### PR TITLE
Move the active page check to before render

### DIFF
--- a/app/components/govuk_component/header_component.html.erb
+++ b/app/components/govuk_component/header_component.html.erb
@@ -32,9 +32,7 @@
           <nav>
             <%= tag.ul(class: navigation_classes, id: "navigation", aria: { label: navigation_label }) do %>
               <% navigation_items.each do |item| %>
-                <%= tag.li(class: item.classes.append(item.active_class), **item.html_attributes) do %>
-                  <%= item %>
-                <% end %>
+                <%= item %>
               <% end %>
             <% end %>
           </nav>

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -61,17 +61,16 @@ private
       @text    = text
       @href    = href
       @options = options
-      @active  = active
+
+      @active_override = active
     end
 
-    def active?
-      return current_page?(href) if active.nil?
-
-      active
+    def before_render
+      @active = active?(@active_override)
     end
 
     def active_class
-      %w(govuk-header__navigation-item--active) if active?
+      %w(govuk-header__navigation-item--active) if @active
     end
 
     def link?
@@ -79,14 +78,22 @@ private
     end
 
     def call
-      if link?
-        link_to(text, href, **options, class: "govuk-header__link")
-      else
-        text
+      tag.li(class: classes.append(active_class), **html_attributes) do
+        if link?
+          link_to(text, href, **options, class: "govuk-header__link")
+        else
+          text
+        end
       end
     end
 
   private
+
+    def active?(active_override)
+      return current_page?(href) if active_override.nil?
+
+      active_override
+    end
 
     def default_classes
       %w(govuk-header__navigation-item)

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -216,7 +216,9 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
         active_link = navigation_items.detect { |item| item[:active] }
 
         expect(rendered_component).to have_tag('nav') do
-          with_tag('li', text: active_link.fetch(:text), with: { class: 'govuk-header__navigation-item--active' }, count: 1)
+          with_tag('li', with: { class: 'govuk-header__navigation-item--active' }) do
+            with_tag('a', text: active_link.fetch(:text), count: 1)
+          end
         end
       end
 
@@ -224,7 +226,9 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
         active_link = navigation_items.detect { |item| item[:href] == current_page }
 
         expect(rendered_component).to have_tag('nav') do
-          with_tag('li', text: active_link.fetch(:text), with: { class: 'govuk-header__navigation-item--active' }, count: 1)
+          with_tag('li', with: { class: 'govuk-header__navigation-item--active' }) do
+            with_tag('a', text: active_link.fetch(:text), count: 1)
+          end
         end
       end
 


### PR DESCRIPTION
This prevents the header from crashing because current_page isn't available when the component is initialised but is when at the point where it's about to render.
