### PR TITLE
Add govuk-body class to the cookie banner message

### DIFF
--- a/app/components/govuk_component/cookie_banner_component/message_component.rb
+++ b/app/components/govuk_component/cookie_banner_component/message_component.rb
@@ -51,7 +51,7 @@ private
   def wrap_in_p(message_text)
     return if message_text.blank?
 
-    tag.p(message_text)
+    tag.p(message_text, class: "govuk-body")
   end
 
   def actions_element

--- a/spec/components/govuk_component/cookie_banner_component_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_component_spec.rb
@@ -64,7 +64,7 @@ RSpec.describe(GovukComponent::CookieBannerComponent, type: :component) do
     specify "renders the message text" do
       expect(rendered_component).to have_tag(message_selector) do
         with_tag("div", with: { class: "govuk-cookie-banner__content" }) do
-          with_tag("p", text: custom_message_text)
+          with_tag("p", text: custom_message_text, with: { class: "govuk-body" })
         end
       end
     end


### PR DESCRIPTION
When the class isn't present it causes the margins to be incorrect.
