### PR TITLE
Add footer navigation block

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,8 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     minitest (5.14.4)
+    nokogiri (1.12.5-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.12.5-x86_64-linux)
       racc (~> 1.4)
     parallel (1.20.1)
@@ -161,6 +163,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
+  x86_64-darwin-20
   x86_64-linux
 
 DEPENDENCIES

--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -1,5 +1,13 @@
 <%= tag.footer(class: classes, role: 'contentinfo', **html_attributes) do %>
   <%= tag.div(class: container_classes, **container_html_attributes) do %>
+    <% if navigation.present? %>
+      <div class="govuk-footer__navigation">
+        <%= navigation %>
+      </div>
+
+      <hr class="govuk-footer__section-break">
+    <% end %>
+
     <%= tag.div(class: meta_classes, **meta_html_attributes) do %>
       <% if meta.present? %>
         <%= meta %>
@@ -31,9 +39,8 @@
             <%= meta_content %>
           <% end %>
         </div>
-        <div class="govuk-footer__meta">
-          <%= tag.div(copyright, class: "govuk-footer__meta-item") %>
-        </div>
+
+        <%= tag.div(copyright, class: "govuk-footer__meta-item") %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -1,6 +1,7 @@
 class GovukComponent::FooterComponent < GovukComponent::Base
   renders_one :meta_html
   renders_one :meta
+  renders_one :navigation
 
   attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright, :custom_container_classes
 

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -223,4 +223,22 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
+
+  describe "navigation" do
+    let(:custom_text) { "Some meta html" }
+    let(:custom_tag) { "span" }
+    let(:custom_html) { helper.content_tag(custom_tag, custom_text) }
+
+    subject! do
+      render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |component|
+        component.navigation { custom_html }
+      end
+    end
+
+    specify "custom HTML is rendered" do
+      expect(rendered_component).to have_tag("div", with: { class: "govuk-footer__navigation" }) do
+        with_tag(custom_tag, text: Regexp.new(custom_text))
+      end
+    end
+  end
 end


### PR DESCRIPTION
We at the Teaching Vacancies service would like to add/improve our navigation links in the footer while switching back to using the default metadata (logo, copyright etc).

CSS and layout is based on the https://gov.uk homepage footer.