### PR TITLE
Hide the cookie banner by default when printing

### DIFF
--- a/app/components/govuk_component/cookie_banner_component.rb
+++ b/app/components/govuk_component/cookie_banner_component.rb
@@ -1,13 +1,14 @@
 class GovukComponent::CookieBannerComponent < GovukComponent::Base
   renders_many :messages, GovukComponent::CookieBannerComponent::MessageComponent
 
-  attr_accessor :aria_label, :hidden
+  attr_accessor :aria_label, :hidden, :hide_in_print
 
-  def initialize(aria_label: "Cookie banner", hidden: false, classes: [], html_attributes: {})
+  def initialize(aria_label: "Cookie banner", hidden: false, hide_in_print: true, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
 
-    @aria_label = aria_label
-    @hidden     = hidden
+    @aria_label    = aria_label
+    @hidden        = hidden
+    @hide_in_print = hide_in_print
   end
 
   def call
@@ -19,6 +20,6 @@ class GovukComponent::CookieBannerComponent < GovukComponent::Base
 private
 
   def default_classes
-    %w(govuk-cookie-banner)
+    class_names("govuk-cookie-banner", "govuk-!-display-none-print" => hide_in_print).split
   end
 end

--- a/spec/components/govuk_component/cookie_banner_component_spec.rb
+++ b/spec/components/govuk_component/cookie_banner_component_spec.rb
@@ -8,10 +8,26 @@ RSpec.describe(GovukComponent::CookieBannerComponent, type: :component) do
     render_inline(described_class.new(**kwargs))
   end
 
-  specify "renders a cookie banner div with the right attributes" do
-    expected_attributes = { class: component_css_class, role: "region", "aria-label" => "Cookie banner" }
+  specify "renders a cookie banner div with the default attributes" do
+    expected_attributes = {
+      class: %w(govuk-cookie-banner govuk-\!-display-none-print),
+      role: "region",
+      "aria-label" => "Cookie banner"
+    }
 
     expect(rendered_component).to have_tag("div", with: expected_attributes)
+  end
+
+  context "when hide_in_print: false" do
+    subject! { render_inline(described_class.new(**kwargs.merge(hide_in_print: false))) }
+
+    specify "the cookie banner does not have the `govuk-!-display-none-print` class" do
+      expect(rendered_component).to have_tag(
+        "div",
+        with: { class: component_css_class },
+        without: { class: "govuk-\\!-display-none-print" }
+      )
+    end
   end
 
   context "when hidden: true" do


### PR DESCRIPTION
Before, the cookie banner component was always displayed.

It makes sense to add the `govuk-!-display-none-print` class by
default so that the cookie banner is hidden when printing a
page.

This can be overriden by setting `hide_when_printing` to false.

Closes #261