### PR TITLE
Tidy up Gemfile.lock

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,9 +47,7 @@ GEM
       nokogiri (>= 1.5.9)
     method_source (1.0.0)
     minitest (5.14.4)
-    nokogiri (1.12.5-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.12.5-x86_64-linux)
+    nokogiri (1.12.5)
       racc (~> 1.4)
     parallel (1.20.1)
     parser (3.0.2.0)
@@ -163,8 +161,7 @@ GEM
     zeitwerk (2.4.2)
 
 PLATFORMS
-  x86_64-darwin-20
-  x86_64-linux
+  ruby
 
 DEPENDENCIES
   govuk-components!
@@ -177,4 +174,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   2.2.24
+   2.2.28


### PR DESCRIPTION
Before, each new platform was listed in the gemfile platforms, and each nokogiri
install was listed.

We can replace these with a default `ruby` platform.