### PR TITLE
Use class_names helper method to conditionally set classes

### DIFF
--- a/app/components/govuk_component/accordion_component/section_component.rb
+++ b/app/components/govuk_component/accordion_component/section_component.rb
@@ -34,8 +34,6 @@ class GovukComponent::AccordionComponent::SectionComponent < GovukComponent::Bas
 private
 
   def default_classes
-    %w(govuk-accordion__section).tap do |classes|
-      classes.append("govuk-accordion__section--expanded") if expanded?
-    end
+    class_names("govuk-accordion__section", "govuk-accordion__section--expanded" => expanded?).split
   end
 end

--- a/app/components/govuk_component/breadcrumbs_component.rb
+++ b/app/components/govuk_component/breadcrumbs_component.rb
@@ -12,10 +12,11 @@ class GovukComponent::BreadcrumbsComponent < GovukComponent::Base
 private
 
   def default_classes
-    %w(govuk-breadcrumbs).tap do |classes|
-      classes << "govuk-!-display-none-print" if hide_in_print
-      classes << "govuk-breadcrumbs--collapse-on-mobile" if collapse_on_mobile
-    end
+    class_names(
+      "govuk-breadcrumbs",
+      "govuk-!-display-none-print" => hide_in_print,
+      "govuk-breadcrumbs--collapse-on-mobile" => collapse_on_mobile
+    ).split
   end
 
   def build_list(breadcrumbs)

--- a/app/components/govuk_component/tab_component.rb
+++ b/app/components/govuk_component/tab_component.rb
@@ -35,9 +35,7 @@ private
     end
 
     def li_classes(i = nil)
-      %w(govuk-tabs__list-item).tap do |c|
-        c.append("govuk-tabs__list-item--selected") if i&.zero?
-      end
+      class_names("govuk-tabs__list-item", "govuk-tabs__list-item--selected" => i&.zero?).split
     end
 
     def li_link

--- a/app/components/govuk_component/table_component/caption_component.rb
+++ b/app/components/govuk_component/table_component/caption_component.rb
@@ -26,9 +26,7 @@ private
   end
 
   def default_classes
-    %w(govuk-table__caption).tap do |c|
-      c << caption_size_class if @size
-    end
+    class_names("govuk-table__caption", caption_size_class => size).split
   end
 
   def caption_size_class

--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -37,19 +37,13 @@ private
 
   def default_classes
     if header
-      %w(govuk-table__header).tap do |c|
-        c << "govuk-table__header--numeric" if numeric?
-        c << width_class if width?
-      end
+      class_names("govuk-table__header", "govuk-table__header--numeric" => numeric?, width_class => width?).split
     else
-      %w(govuk-table__cell).tap do |c|
-        c << "govuk-table__cell--numeric" if numeric?
-        c << width_class if width?
-      end
+      class_names("govuk-table__cell", "govuk-table__cell--numeric" => numeric?, width_class => width?).split
     end
   end
 
   def width_class
-    WIDTHS.fetch(width)
+    WIDTHS.fetch(width, nil)
   end
 end


### PR DESCRIPTION
Before, classes were conditionally added by tapping an array of classes and
conditionally appending classes.

Now, the `class_names` helper is used consistently to add conditional classes.