### PR TITLE
add semicolon to copyright html entity

### DIFF
--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -77,7 +77,7 @@ private
   end
 
   def default_copright_text
-    raw(%(&copy Crown copyright))
+    raw(%(&copy; Crown copyright))
   end
 
   def default_copyright_url


### PR DESCRIPTION
being a bit ocd maybe but IE throws a little warning for this

![Screenshot 2021-12-01 at 14 16 36](https://user-images.githubusercontent.com/1792451/144250311-0faeced2-d2f7-4911-b00d-21ca0ab0120f.png)
