### PR TITLE
Add actions keyword to summary list component

### DIFF
--- a/app/components/govuk_component/summary_list_component.rb
+++ b/app/components/govuk_component/summary_list_component.rb
@@ -1,17 +1,21 @@
 module GovukComponent
   class SummaryListComponent < GovukComponent::Base
-    attr_reader :borders
+    attr_reader :borders, :actions
 
-    renders_many :rows, "GovukComponent::SummaryListComponent::RowComponent"
-
-    def initialize(borders: true, classes: [], html_attributes: {})
-      super(classes: classes, html_attributes: html_attributes)
-
-      @borders = borders
+    renders_many :rows, ->(classes: [], html_attributes: {}, &block) do
+      GovukComponent::SummaryListComponent::RowComponent.new(
+        show_actions_column: @show_actions_column,
+        classes: classes,
+        html_attributes: html_attributes,
+        &block
+      )
     end
 
-    def any_row_has_actions?
-      rows.any? { |row| row.href.present? }
+    def initialize(actions: true, borders: true, classes: [], html_attributes: {})
+      super(classes: classes, html_attributes: html_attributes)
+
+      @borders             = borders
+      @show_actions_column = actions
     end
 
     def classes

--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -9,12 +9,11 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
     @visually_hidden_text = visually_hidden_text
   end
 
-  def call
-    # when no href is provided return an empty string so the dd container
-    # will render, it's useful in lists where some rows have actions
-    # and others don't
-    return "" if href.blank?
+  def render?
+    href.present?
+  end
 
+  def call
     link_classes = govuk_link_classes.append(classes).flatten
 
     link_to(href, class: link_classes, **html_attributes) do

--- a/app/components/govuk_component/summary_list_component/row_component.rb
+++ b/app/components/govuk_component/summary_list_component/row_component.rb
@@ -1,12 +1,14 @@
 class GovukComponent::SummaryListComponent::RowComponent < GovukComponent::Base
-  attr_reader :href, :visually_hidden_text
+  attr_reader :href, :visually_hidden_text, :show_actions_column
 
   renders_one :key, GovukComponent::SummaryListComponent::KeyComponent
   renders_one :value, GovukComponent::SummaryListComponent::ValueComponent
   renders_many :actions, GovukComponent::SummaryListComponent::ActionComponent
 
-  def initialize(classes: [], html_attributes: {})
+  def initialize(show_actions_column: nil, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)
+
+    @show_actions_column = show_actions_column
   end
 
   def call
@@ -18,7 +20,7 @@ class GovukComponent::SummaryListComponent::RowComponent < GovukComponent::Base
 private
 
   def actions_content
-    return if actions.blank?
+    return unless show_actions_column && actions.any?
 
     (actions.one?) ? single_action : actions_list
   end
@@ -36,7 +38,9 @@ private
   end
 
   def default_classes
-    %w(govuk-summary-list__row)
+    %w(govuk-summary-list__row).tap do |c|
+      c << "govuk-summary-list__row--no-actions" if show_actions_column && actions.none?
+    end
   end
 
   def actions_class

--- a/guide/content/components/summary-list.slim
+++ b/guide/content/components/summary-list.slim
@@ -22,6 +22,20 @@ p
     example below, we can provide the `visually_hidden_text` argument to
     describe what we’re changing.
 
+    The summary list expects rows to have actions, rows without actions
+    will automatically have the class `govuk-summary-list__row--no-actions`
+    applied to maintain consistent alignment.
+
     The visually hidden text will be rendered immediately after the link.
+
+== render('/partials/example.*',
+  caption: "Summary lists without actions",
+  code: summary_list_without_actions) do
+
+  markdown:
+    When there are no user actions and the summary list is only used to
+    display static information, the actions column can be hidden entirely
+    using `actions: false`. Doing this makes the values column wider
+    consuming the remaining space.
 
 == render('/partials/related-info.*', links: summary_list_info)

--- a/guide/lib/examples/summary_list_helpers.rb
+++ b/guide/lib/examples/summary_list_helpers.rb
@@ -18,7 +18,29 @@ module Examples
             - row.key(text: 'Chinchilla')
             - row.value(text: 'Either of two species of crepuscular rodents')
             - row.action(text: 'Change', visually_hidden_text: 'chinchillas', href: '#')
+
+          - summary_list.row do |row|
+            - row.key(text: 'Dugong')
+            - row.value(text: 'Dugongs are a species of sea cow')
       SUMMARY_LIST
+    end
+
+    def summary_list_without_actions
+      <<~SUMMARY_LIST_WITHOUT_ACTIONS
+        = govuk_summary_list(actions: false) do |summary_list|
+          - summary_list.row do |row|
+            - row.key { 'Name' }
+            - row.value { 'Sherlock Holmes' }
+
+          - summary_list.row do |row|
+            - row.key(text: 'Address')
+            - row.value do
+              | 221B Baker Street, Westminster, London, NW1 6XE, England
+
+          - summary_list.row do |row|
+            - row.key(text: 'Phone number')
+            - row.value(text: '020 123 1234')
+      SUMMARY_LIST_WITHOUT_ACTIONS
     end
   end
 end

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
     end
   end
 
-  context "when some rows don't have actions" do
+  context "when one row has actions and one does not" do
     subject! do
       render_inline(described_class.new(**kwargs)) do |component|
         component.row do |row|
@@ -122,15 +122,47 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
             [row.key(text: "Key"), row.value(text: "Value"), row.action(href: nil)]
           )
         end
+
+        component.row do |row|
+          helper.safe_join(
+            [row.key(text: "Key"), row.value(text: "Value")]
+          )
+        end
       end
     end
 
-    specify "renders an empty action column" do
+    specify "renders one row with the govuk-summary-list__row--no-actions class and no actions" do
       expect(rendered_component).to have_tag("dl", with: { class: component_css_class }) do
-        with_tag("div", with: { class: %(govuk-summary-list__row) }) do
-          with_tag("dd", with: { class: "govuk-summary-list__actions" }, text: "")
+        with_tag("div", with: { class: %(govuk-summary-list__row govuk-summary-list__row--no-actions) }, count: 1) do
+          without_tag("dd", with: { class: "govuk-summary-list__actions" })
         end
       end
+    end
+
+    specify "renders one row with actions" do
+      expect(rendered_component).to have_tag("dl", with: { class: component_css_class }) do
+        with_tag("div", with: { class: %(govuk-summary-list__row) }) do
+          with_tag("dd", with: { class: "govuk-summary-list__actions" }, count: 1)
+        end
+      end
+    end
+  end
+
+  context "when 'actions: false'" do
+    subject! do
+      render_inline(described_class.new(actions: false, **kwargs)) do |component|
+        component.row { |row| helper.safe_join([row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/a")]) }
+        component.row { |row| helper.safe_join([row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/b")]) }
+        component.row { |row| helper.safe_join([row.key(text: "Key"), row.value(text: "Value")]) }
+      end
+    end
+
+    specify "no actions are rendered, even when they're called on the row" do
+      expect(rendered_component).not_to have_tag("dd", with: { class: "govuk-summary-list__actions" })
+    end
+
+    specify "no rows have the class 'govuk-summary-list__row--no-actions'" do
+      expect(rendered_component).not_to have_tag("div", with: { class: %(govuk-summary-list__row govuk-summary-list__row--no-actions) })
     end
   end
 


### PR DESCRIPTION
Version 4.0.0 of the design system changes the behaviour of summary lists. Instead of adding an empty actions column the .govuk-summary-list__row--no-actions class is applied to the row and it will add a column as a pseudoelement via CSS.

As we're building lists in a DSL fashion, our nodes don't know about their siblings; we can't work out whether any other rows have actions. We need to _tell_ the summary list how to act and it will apply the classes automatically.

This work also paves the way for an alternative syntax where we pass in an array of hashes/objects - this would work how the table works. In this case (because we can see the objects up front) we _can_ take care of this automatically.
