### PR TITLE
Add paragraph to the guide on danger of capturing objects

### DIFF
--- a/guide/content/introduction/using-components.slim
+++ b/guide/content/introduction/using-components.slim
@@ -12,6 +12,27 @@ markdown:
   The result and functionality of the components is the same
   regardless of approach.
 
+  ## Capturing content
+
+  This library uses Rails' default capture functionalty. It's intended to work
+  with strings but [renders nothing](https://github.com/rails/rails/issues/17661)
+  when other kinds of objects are provided. For example, if we capture a
+  floating point number and a string in a `tag#span` block, only the string is
+  rendered.
+
+.code-sample
+  pre
+    code.highlight.language-slim
+      |
+        = tag.span { 1.0 }
+        = tag.span { "2.0" }
+
+  pre
+    code.highlight.language-html
+        = "<span></span>\n"
+        = "<span>2.0</span>"
+
+markdown:
   ## Using component objects directly
 
   Rails supports the rendering of ViewComponent objects natively. You can

--- a/guide/content/stylesheets/components/_prose.scss
+++ b/guide/content/stylesheets/components/_prose.scss
@@ -80,6 +80,10 @@
     }
   }
 
+  .code-sample {
+    margin-bottom: govuk-spacing(8);
+  }
+
   .header-anchor {
     color: $govuk-text-colour;
     margin-left: -1.5ch;


### PR DESCRIPTION
Rails not rendering anything captured that's not a string trips a few people up. It isn't the most intuitive of Rails' behaviours. A section in the guide could be helpful for people who encounter it.
