### PR TITLE
Add a .semgrepignore file

### DIFF
--- a/.semgrepignore
+++ b/.semgrepignore
@@ -1,0 +1,1 @@
+spec/dummy/


### PR DESCRIPTION
Semgrep is reporting a security lapse in the test app (spec/dummy). Clearly it's not important so let's ignore it.
