### PR TITLE
Bump view component to 2.49.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     govuk-components (3.0.2)
       activemodel (>= 6.1)
       railties (>= 6.1)
-      view_component (~> 2.47.0)
+      view_component (~> 2.49.1)
 
 GEM
   remote: https://rubygems.org/

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |spec|
     spec.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)
   end
 
-  spec.add_dependency "view_component", "~> 2.47.0"
+  spec.add_dependency "view_component", "~> 2.49.1"
 
   spec.add_development_dependency "pry-byebug"
   spec.add_development_dependency "rspec-html-matchers", "~> 0.9"


### PR DESCRIPTION
This fixes a dependabot XSS vulnerability advisory: https://github.com/DFE-Digital/find-a-lost-trn/security/dependabot/4

Tests pass locally:

```bash
$ bundle exec rspec 
............................................................................................................................................................................................................................................................................................................................................................... 
Finished in 0.55705 seconds (files took 1.8 seconds to load) 
351 examples, 0 failures 
Coverage report generated for RSpec to /home/deity/git/govuk-components/coverage. 2338 / 2344 LOC (99.74%) covered. 
```