### PR TITLE
Add a sitemap to the guide

### DIFF
--- a/guide/Rules
+++ b/guide/Rules
@@ -26,6 +26,11 @@ compile '/**/*.scss' do
   write item.identifier.without_ext + '.css'
 end
 
+compile '/sitemap.xml' do
+  filter :erb
+  write '/sitemap.xml'
+end
+
 compile '/**/*' do
   write item.identifier.to_s
 end

--- a/guide/content/hello.slim
+++ b/guide/content/hello.slim
@@ -1,3 +1,0 @@
-h1 Hello world
-
-== ActionController::Base.render(GovukComponent::PanelComponent.new(title_text: "hi", text: "there"))

--- a/guide/content/index.slim
+++ b/guide/content/index.slim
@@ -1,2 +1,6 @@
+---
+priority: 1
+---
+
 == render '/partials/masthead.*'
 == render '/partials/links.*'

--- a/guide/content/sitemap.xml
+++ b/guide/content/sitemap.xml
@@ -1,0 +1,1 @@
+<%= xml_sitemap(items: items.select { |item| item.identifier.ext == "slim" }) %>

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -9,6 +9,7 @@ Dir.glob(File.join('./lib', '**', '*.rb')).sort.each { |f| require f }
 
 use_helper Nanoc::Helpers::Rendering
 use_helper Nanoc::Helpers::LinkTo
+use_helper Nanoc::Helpers::XMLSitemap
 use_helper Helpers::LinkHelpers
 use_helper Helpers::TitleAnchorHelpers
 use_helper Helpers::Formatters

--- a/guide/nanoc.yaml
+++ b/guide/nanoc.yaml
@@ -1,7 +1,7 @@
 # A list of file extensions that Nanoc will consider to be textual rather than
 # binary. If an item with an extension not in this list is found,  the file
 # will be considered as binary.
-text_extensions: ['slim', 'js', 'css', 'sass', 'scss', 'erb', 'html', 'md']
+text_extensions: ['slim', 'js', 'css', 'sass', 'scss', 'erb', 'html', 'md', 'xml']
 
 prune:
   auto_prune: true
@@ -16,3 +16,5 @@ checks:
       # ruby doc sometimes fails because the docs are built when the request is
       # made which nano reports as failure (202)
       - '^https?://www.rubydoc.info/'
+
+base_url: https://govuk-components.netlify.app


### PR DESCRIPTION
The Nanoc helper makes this really easy, we're using Nanoc's list of items so partials aren't included and we just need to filter to slim files in `xml_sitemap`.

This doesn't set `changefreq` - not sure how important they are. If we add them they needed to be added to each page's frontmatter individually, probably set to `yearly`
