### PR TITLE
Update supported versions to latest Ruby and Rails

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7.5', '3.0.3', '3.1.0']
-        rails: ['6.1.4.4', '7.0.1']
+        ruby: ['2.7.6', '3.0.4', '3.1.2']
+        rails: ['6.1.5', '7.0.2']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:
@@ -40,7 +40,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.3
+          ruby-version: 3.0.4
 
       - name: Install gems
         run: |

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   exact_rails_version = ENV.key?("RAILS_VERSION")
-  rails_version = ENV.fetch("RAILS_VERSION") { "6.1.4.4" }
+  rails_version = ENV.fetch("RAILS_VERSION") { "6.1.5" }
 
   %w(activemodel railties).each do |lib|
     spec.add_dependency(*VersionFormatter.new(lib, rails_version, exact_rails_version).to_a)

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -23,16 +23,16 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | GOV.UK Design System
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 4.0.0
+        | 4.0.1
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.14.0
     tr.govuk-table__row
       th.govuk-table__header scope="row"
         | Ruby on Rails
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 7.0.2
+        | 7.0.4
         br
-        | 6.1.4.4
+        | 6.1.5
       td.govuk-table__cell.govuk-table__cell--numeric
         | 6.1.4.4
         br
@@ -41,11 +41,11 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | Ruby
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 3.1.0
+        | 3.1.2
         br
-        | 3.0.3
+        | 3.0.4
         br
-        | 2.7.5
+        | 2.7.6
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.0.3
         br


### PR DESCRIPTION
The supported versions will be:

### Ruby:

* 2.7.6
* 3.0.4
* 3.1.2

### Rails:

* 7.0.2
* 6.1.5
