### PR TITLE
Fix some broken guide links in the `README`

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,7 @@ All of the non-form components from the GOV.UK Design System are implemented by 
 The provided components are:
 
 * [Accordion](https://govuk-components.netlify.app/components/accordion)
-* [Back link](https://govuk-components.netlify.app/components/back-links)
-* [Back to top link](https://govuk-components.netlify.app/components/back-to-top-link)
+* [Back link](https://govuk-components.netlify.app/components/back-link)
 * [Breadcrumbs](https://govuk-components.netlify.app/components/breadcrumbs)
 * [Cookie banner](https://govuk-components.netlify.app/components/cookie-banner)
 * [Details](https://govuk-components.netlify.app/components/details)
@@ -32,7 +31,6 @@ The provided components are:
 * [Notification banner](https://govuk-components.netlify.app/components/notification-banner)
 * [Panel](https://govuk-components.netlify.app/components/panel)
 * [Phase banner](https://govuk-components.netlify.app/components/phase-banner)
-* [Skip link](https://govuk-components.netlify.app/components/skip-link)
 * [Start button](https://govuk-components.netlify.app/components/start-button)
 * [Summary list](https://govuk-components.netlify.app/components/summary-list)
 * [Tabs](https://govuk-components.netlify.app/components/tabs)

--- a/README.md
+++ b/README.md
@@ -38,8 +38,9 @@ The provided components are:
 * [Tags](https://govuk-components.netlify.app/components/tag)
 * [Warning text](https://govuk-components.netlify.app/components/warning-text)
 
-This library also provides [link](https://govuk-components.netlify.app/helpers/link) and
-[button](https://govuk-components.netlify.app/helpers/button) helpers.
+This library also provides helpers for creating [links](https://govuk-components.netlify.app/helpers/link),
+[buttons](https://govuk-components.netlify.app/helpers/button), [skip links](https://govuk-components.netlify.app/helpers/skip-link)
+and [back to top links](https://govuk-components.netlify.app/helpers/back-to-top-link).
 
 ## Alternative syntax
 

--- a/app/helpers/govuk_back_to_top_link_helper.rb
+++ b/app/helpers/govuk_back_to_top_link_helper.rb
@@ -1,6 +1,6 @@
 module GovukBackToTopLinkHelper
-  def govuk_back_to_top_link
-    link_to '#top', class: 'govuk-link govuk-link--no-visited-state' do
+  def govuk_back_to_top_link(target = '#top')
+    link_to(target, class: 'govuk-link govuk-link--no-visited-state') do
       <<-HTML.squish.html_safe
       <svg class="app-back-to-top__icon" xmlns="http://www.w3.org/2000/svg" width="13" height="17" viewBox="0 0 13 17">
         <path fill="currentColor" d="M6.5 0L0 6.5 1.4 8l4-4v12.7h2V4l4.3 4L13 6.4z"></path>

--- a/guide/content/helpers/back-to-top-link.slim
+++ b/guide/content/helpers/back-to-top-link.slim
@@ -1,0 +1,18 @@
+---
+title: Back to top link
+---
+
+#top
+  markdown:
+    Back to top links help users quickly navigate back to the top of long pages
+    of content.
+
+    Many operating systems and browsers do support scrolling back to the top
+    automatically but many users are unaware of the functionality.
+
+== render('/partials/example.*',
+  caption: "A default back to top link",
+  code: govuk_back_to_top_link_with_custom_target) do
+
+  p When no target <code>id</code> is provided the back to top link will
+    default to <code>#top</code>.

--- a/guide/layouts/partials/links.slim
+++ b/guide/layouts/partials/links.slim
@@ -16,6 +16,7 @@ section#links.govuk-width-container
         li== govuk_link_to('Button', '/helpers/button')
         li== govuk_link_to('Link', '/helpers/link')
         li== govuk_link_to('Skip link', '/helpers/skip-link')
+        li== govuk_link_to('Back to top link', '/helpers/back-to-top-link')
 
     .govuk-grid-column-two-thirds
       h2.govuk-heading-m Components

--- a/guide/lib/examples/back_to_top_link_helpers.rb
+++ b/guide/lib/examples/back_to_top_link_helpers.rb
@@ -1,0 +1,7 @@
+module Examples
+  module BackToTopLinkHelpers
+    def govuk_back_to_top_link_with_custom_target
+      %(= govuk_back_to_top_link("#top"))
+    end
+  end
+end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -78,3 +78,4 @@ use_helper Examples::TabsHelpers
 use_helper Examples::TagHelpers
 use_helper Examples::WarningTextHelpers
 use_helper Examples::CommonOptionsHelpers
+use_helper Examples::BackToTopLinkHelpers

--- a/spec/helpers/govuk_back_to_top_link_helper_spec.rb
+++ b/spec/helpers/govuk_back_to_top_link_helper_spec.rb
@@ -13,5 +13,13 @@ RSpec.describe(GovukBackToTopLinkHelper, type: 'helper') do
         with_tag('svg')
       end
     end
+
+    context "when the target is overridden" do
+      subject { govuk_back_to_top_link("#pinacle") }
+
+      it "renders a back to top link with a custom target" do
+        expect(subject).to have_tag('a', with: { href: '#pinacle' })
+      end
+    end
   end
 end


### PR DESCRIPTION
While fixing the links I also took the opportunity to add a guide page for the forgotten 'back to top' helper and to allow it to take a custom target.

It's probably worth revisiting the link helpers and standardising their behaviour a bit more. The 'back link' component could be converted to a helper too, it would make more sense than it being a fully-fledged ViewComponent.

## Changes

- Remove the back to top and skip links from readme
- Allow govuk_back_to_top_link to take custom target
- Add guide page for back to top link
