### PR TITLE
Add a section break component

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,8 @@ PATH
   remote: .
   specs:
     govuk-components (3.0.4)
-      activemodel (~> 6.1.4.4, >= 6.1)
-      railties (~> 6.1.4.4, >= 6.1)
+      activemodel (>= 6.1)
+      railties (>= 6.1)
       view_component (~> 2.49.1)
 
 GEM

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ The provided components are:
 * [Notification banner](https://govuk-components.netlify.app/components/notification-banner)
 * [Panel](https://govuk-components.netlify.app/components/panel)
 * [Phase banner](https://govuk-components.netlify.app/components/phase-banner)
+* [Section break](https://govuk-components.netlify.app/components/section-break)
 * [Start button](https://govuk-components.netlify.app/components/start-button)
 * [Summary list](https://govuk-components.netlify.app/components/summary-list)
 * [Tabs](https://govuk-components.netlify.app/components/tabs)

--- a/app/components/govuk_component/section_break_component.rb
+++ b/app/components/govuk_component/section_break_component.rb
@@ -1,0 +1,40 @@
+class GovukComponent::SectionBreakComponent < GovukComponent::Base
+  SIZES = %w(m l xl).freeze
+
+  def initialize(visible: false, size: nil, classes: [], html_attributes: {})
+    super(classes: classes, html_attributes: html_attributes)
+
+    @visible = visible
+    @size    = size
+  end
+
+  def call
+    tag.hr(class: classes, **html_attributes)
+  end
+
+private
+
+  attr_reader :size, :visible
+
+  def default_classes
+    class_names(
+      "govuk-section-break",
+      size_class,
+      "govuk-section-break--visible" => visible?
+    ).split
+  end
+
+  def size_class
+    if size.blank?
+      ""
+    elsif size.in?(SIZES)
+      "govuk-section-break--#{size}"
+    else
+      raise ArgumentError, "invalid size #{size}, supported sizes are #{SIZES.to_sentence}"
+    end
+  end
+
+  def visible?
+    visible
+  end
+end

--- a/app/helpers/govuk_components_helper.rb
+++ b/app/helpers/govuk_components_helper.rb
@@ -11,6 +11,7 @@ module GovukComponentsHelper
     govuk_notification_banner: 'GovukComponent::NotificationBannerComponent',
     govuk_panel: 'GovukComponent::PanelComponent',
     govuk_phase_banner: 'GovukComponent::PhaseBannerComponent',
+    govuk_section_break: 'GovukComponent::SectionBreakComponent',
     govuk_start_button: 'GovukComponent::StartButtonComponent',
     govuk_summary_list: 'GovukComponent::SummaryListComponent',
     govuk_table: 'GovukComponent::TableComponent',

--- a/guide/content/components/section-break.slim
+++ b/guide/content/components/section-break.slim
@@ -1,0 +1,16 @@
+---
+title: Section break
+---
+
+p
+  | Use a section break component when you want to create a thematic break between sections of content.
+
+== render('/partials/example.*',
+  caption: "Section break with a visible separator line",
+  code: section_break_visible)
+
+== render('/partials/example.*',
+  caption: "Section break with a visible separator line and an extra large margin",
+  code: section_break_visible_xl)
+
+== render('/partials/related-info.*', links: section_break_info)

--- a/guide/lib/examples/section_break_helpers.rb
+++ b/guide/lib/examples/section_break_helpers.rb
@@ -1,0 +1,15 @@
+module Examples
+  module SectionBreakHelpers
+    def section_break_visible
+      <<~SECTION_BREAK
+        = govuk_section_break(visible: true)
+      SECTION_BREAK
+    end
+
+    def section_break_visible_xl
+      <<~SECTION_BREAK
+        = govuk_section_break(visible:true, size: "xl")
+      SECTION_BREAK
+    end
+  end
+end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -38,6 +38,7 @@ require 'components/govuk_component/inset_text_component'
 require 'components/govuk_component/notification_banner_component'
 require 'components/govuk_component/panel_component'
 require 'components/govuk_component/phase_banner_component'
+require 'components/govuk_component/section_break_component'
 require 'components/govuk_component/start_button_component'
 require 'components/govuk_component/summary_list_component'
 require 'components/govuk_component/summary_list_component/key_component'
@@ -70,6 +71,7 @@ use_helper Examples::InsetTextHelpers
 use_helper Examples::NotificationBannerHelpers
 use_helper Examples::PanelHelpers
 use_helper Examples::PhaseBannerHelpers
+use_helper Examples::SectionBreakHelpers
 use_helper Examples::SkipLinkHelpers
 use_helper Examples::StartButtonHelpers
 use_helper Examples::SummaryListHelpers

--- a/guide/lib/helpers/content_helpers.rb
+++ b/guide/lib/helpers/content_helpers.rb
@@ -65,6 +65,12 @@ module Helpers
       }
     end
 
+    def section_break_info
+      {
+        "GOV.UK Design System section break documentation" => "https://design-system.service.gov.uk/styles/typography/#section-break"
+      }
+    end
+
     def start_button_info
       {
         "GOV.UK Design System start button documentation" => "https://design-system.service.gov.uk/components/button/#start-buttons"

--- a/spec/components/govuk_component/section_break_component_spec.rb
+++ b/spec/components/govuk_component/section_break_component_spec.rb
@@ -1,0 +1,71 @@
+require "spec_helper"
+
+RSpec.describe GovukComponent::SectionBreakComponent, type: :component do
+  let(:component_css_class) { "govuk-section-break" }
+  let(:kwargs) { {} }
+
+  it_behaves_like "a component that accepts custom classes"
+  it_behaves_like "a component that accepts custom HTML attributes"
+
+  context "when visible is true" do
+    it "renders the section break with the visible class" do
+      component = GovukComponent::SectionBreakComponent.new(visible: true)
+
+      render_inline(component)
+
+      expect(rendered_component).to have_tag(
+        "hr",
+        with: { class: [component_css_class, "govuk-section-break--visible"] }
+      )
+    end
+  end
+
+  context "when visible is false" do
+    it "renders the section break without the visible class" do
+      component = GovukComponent::SectionBreakComponent.new(visible: false)
+
+      render_inline(component)
+
+      expect(rendered_component).to have_tag(
+        "hr",
+        with: { class: [component_css_class] },
+        without: { class: ["govuk-section-break--visible"] }
+      )
+    end
+  end
+
+  context "when size is blank" do
+    it "renders the section break without the size class" do
+      component = GovukComponent::SectionBreakComponent.new
+
+      render_inline(component)
+
+      expect(rendered_component).to have_tag(
+        "hr",
+        with: { class: [component_css_class] }
+      )
+    end
+  end
+
+  context "when size is valid" do
+    it "renders the section break with the size class" do
+      component = GovukComponent::SectionBreakComponent.new(size: "xl")
+
+      render_inline(component)
+
+      expect(rendered_component).to have_tag(
+        "hr",
+        with: { class: [component_css_class, "govuk-section-break--xl"] }
+      )
+    end
+  end
+
+  context "when size is invalid" do
+    it "raises an error" do
+      component = GovukComponent::SectionBreakComponent.new(size: "s")
+
+      expect { render_inline(component) }
+        .to raise_error(ArgumentError, "invalid size s, supported sizes are m, l, and xl")
+    end
+  end
+end

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -96,6 +96,13 @@ RSpec.describe(GovukComponentsHelper, type: 'helper') do
       css_matcher: %(.govuk-phase-banner)
     },
     {
+      helper_method: :govuk_section_break,
+      klass: GovukComponent::SectionBreakComponent,
+      args: [],
+      kwargs: {},
+      css_matcher: %(.govuk-section-break)
+    },
+    {
       helper_method: :govuk_start_button,
       klass: GovukComponent::StartButtonComponent,
       args: [],


### PR DESCRIPTION
In the Typography section of the design system, there is a part on the [Section
break element](https://design-system.service.gov.uk/styles/typography/#section-break).

This adds a component (and respective helper method) for rendering a section
break element, as suggested in #321.

The visibility and size of the component is configurable.