### PR TITLE
Add missing attributes to #govuk_button_link_to

### DIFF
--- a/app/components/govuk_component/start_button_component.rb
+++ b/app/components/govuk_component/start_button_component.rb
@@ -1,4 +1,10 @@
 class GovukComponent::StartButtonComponent < GovukComponent::Base
+  BUTTON_ATTRIBUTES = {
+    role: 'button',
+    draggable: 'false',
+    data: { module: 'govuk-button' }
+  }
+
   attr_reader :text, :href
 
   def initialize(text:, href:, classes: [], html_attributes: {})
@@ -17,12 +23,7 @@ class GovukComponent::StartButtonComponent < GovukComponent::Base
 private
 
   def default_attributes
-    {
-      role: 'button',
-      draggable: 'false',
-      class: classes,
-      data: { module: 'govuk-button' }
-    }
+    BUTTON_ATTRIBUTES.merge class: classes
   end
 
   def default_classes

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -68,7 +68,8 @@ module GovukLinkHelper
 
   def govuk_button_link_to(name = nil, options = nil, extra_options = {}, &block)
     extra_options = options if block_given?
-    html_options = build_html_options(extra_options, style: :button)
+    html_options = GovukComponent::StartButtonComponent::BUTTON_ATTRIBUTES
+      .merge build_html_options(extra_options, style: :button)
 
     if block_given?
       link_to(name, html_options, &block)

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -221,7 +221,13 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       subject { govuk_button_link_to(button_text, button_params) }
 
       specify "renders a link styled as a button with the correct attributes" do
-        expect(subject).to have_tag("a", with: { href: button_url, class: "govuk-button" })
+        expect(subject).to have_tag("a", with: {
+          href: button_url,
+          class: "govuk-button",
+          draggable: false,
+          role: "button",
+          "data-module": "govuk-button"
+        })
       end
     end
 


### PR DESCRIPTION
This was missing some of the attributes that the design system recommends for links that are styled as buttons:

https://design-system.service.gov.uk/components/button/start/index.html

User provided attributes still get `.merge`d on top, so this shouldn't break any existing overrides if someone has added these attributes manually. This is backwards compatible and is a bugfix or new feature depending on how you look at it.

### Screenshot from the deploy preview
![image](https://user-images.githubusercontent.com/1650875/170980700-3b760d5e-8959-4056-b9e0-c77091f5c35b.png)
