### PR TITLE
Remove all traces of `custom_classes`

### DIFF
--- a/app/components/govuk_component/traits/custom_classes.rb
+++ b/app/components/govuk_component/traits/custom_classes.rb
@@ -1,4 +1,0 @@
-module GovukComponent
-  module Traits
-  end
-end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -22,7 +22,6 @@ require 'govuk/components'
 
 require 'components/govuk_component'
 require 'components/govuk_component/traits'
-require 'components/govuk_component/traits/custom_classes'
 require 'components/govuk_component/traits/custom_html_attributes'
 require 'components/govuk_component/base'
 require 'components/govuk_component/accordion_component'


### PR DESCRIPTION
This should've been done when `CustomClasses` was dropped but the empty file was forgotten. The tests all passed outside of Rails but fell foul of Zeitwork, causing [apps to fail](#330).