### PR TITLE
Handle `classes: nil` more gracefully

### DIFF
--- a/app/components/govuk_component/base.rb
+++ b/app/components/govuk_component/base.rb
@@ -4,6 +4,11 @@ class GovukComponent::Base < ViewComponent::Base
   attr_reader :html_attributes
 
   def initialize(classes:, html_attributes:)
+    if classes.nil?
+      Rails.logger.warn("classes is nil, if no custom classes are needed omit the param")
+
+      classes = []
+    end
     # FIXME: remove first merge when we deprecate classes
     #
     # This step only needs to be here while we still accept classes:, now

--- a/spec/components/shared/a_component_that_accepts_custom_classes.rb
+++ b/spec/components/shared/a_component_that_accepts_custom_classes.rb
@@ -1,19 +1,34 @@
 shared_examples 'a component that accepts custom classes' do
-  before { render_inline(described_class.send(:new, **kwargs.merge(classes: custom_classes))) }
+  context 'when classes are supplied' do
+    before { render_inline(described_class.send(:new, **kwargs.merge(classes: custom_classes))) }
 
-  context 'when classes are supplied as a string' do
-    let(:custom_classes) { 'yellow-spots black-text' }
+    context 'as a string' do
+      let(:custom_classes) { 'yellow-spots black-text' }
 
-    specify 'the classes are present in the rendered output' do
-      expect(rendered_content).to have_tag(component_css_class_matcher, with: { class: custom_classes.split })
+      specify 'the classes are present in the rendered output' do
+        expect(rendered_content).to have_tag(component_css_class_matcher, with: { class: custom_classes.split })
+      end
+    end
+
+    context 'as an array' do
+      let(:custom_classes) { %w(purple-stripes yellow-background) }
+
+      specify 'the classes are present in the rendered output' do
+        expect(rendered_content).to have_tag(component_css_class_matcher, with: { class: custom_classes })
+      end
     end
   end
 
-  context 'when classes are supplied as an array' do
-    let(:custom_classes) { %w(purple-stripes yellow-background) }
+  context 'when classes are nil' do
+    let(:custom_classes) { nil }
+
+    before do
+      allow(Rails.logger).to receive(:warn).and_return(true)
+      render_inline(described_class.send(:new, **kwargs.merge(classes: custom_classes)))
+    end
 
     specify 'the classes are present in the rendered output' do
-      expect(rendered_content).to have_tag(component_css_class_matcher, with: { class: custom_classes })
+      expect(Rails.logger).to have_received(:warn).with(/classes is nil/)
     end
   end
 end


### PR DESCRIPTION
When the classes param is `nil` the library fails while attempting to append conditional classes to it. The error message doesn't make it obvious what the problem is.

Here we are addressing it by emitting a warning when nil classes are detected and overwriting the nil with an empty array.

Fixes #334
