### PR TITLE
Only build pagy items before render

### DIFF
--- a/app/components/govuk_component/pagination_component.rb
+++ b/app/components/govuk_component/pagination_component.rb
@@ -49,12 +49,12 @@ class GovukComponent::PaginationComponent < GovukComponent::Base
     @block_mode                    = block_mode
     @landmark_label                = landmark_label
 
-    build_items if pagy.present?
-
     super(classes: classes, html_attributes: html_attributes)
   end
 
   def before_render
+    build_items if pagy.present?
+
     @page_items       = items || build_items
     @previous_content = previous_page || build_previous
     @next_content     = next_page || build_next


### PR DESCRIPTION
When running in a real Rails app (vs a mocked one) we don't have all the information we need when the component is initialised and instead need to wait for the point just before it's rendered.

Tested and confirmed working in the Rails template:

![image](https://user-images.githubusercontent.com/128088/176007699-c802c09f-01ba-4385-8244-c6915dfa5677.png)


