### PR TITLE
Allow start button to be a button

### DIFF
--- a/app/components/govuk_component/start_button_component.rb
+++ b/app/components/govuk_component/start_button_component.rb
@@ -1,29 +1,38 @@
 class GovukComponent::StartButtonComponent < GovukComponent::Base
   BUTTON_ATTRIBUTES = {
-    role: 'button',
     draggable: 'false',
     data: { module: 'govuk-button' }
   }.freeze
 
-  attr_reader :text, :href
+  LINK_ATTRIBUTES = BUTTON_ATTRIBUTES.merge({ role: 'button' }).freeze
 
-  def initialize(text:, href:, classes: [], html_attributes: {})
+  attr_reader :text, :href, :as_button
+
+  def initialize(text:, href:, as_button: false, classes: [], html_attributes: {})
     @text = text
     @href = href
+    @as_button = as_button
 
     super(classes: classes, html_attributes: html_attributes)
   end
 
   def call
-    link_to(href, **html_attributes) do
-      safe_join([text, icon])
+    if as_button
+      button_to(href, **html_attributes) do
+        safe_join([text, icon])
+      end
+    else
+      link_to(href, **html_attributes) do
+        safe_join([text, icon])
+      end
     end
   end
 
 private
 
   def default_attributes
-    BUTTON_ATTRIBUTES.merge({ class: %w(govuk-button govuk-button--start) })
+    (as_button ? BUTTON_ATTRIBUTES : LINK_ATTRIBUTES)
+      .merge({ class: %w(govuk-button govuk-button--start) })
   end
 
   def icon

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -68,7 +68,7 @@ module GovukLinkHelper
 
   def govuk_button_link_to(name = nil, options = nil, extra_options = {}, &block)
     extra_options = options if block_given?
-    html_options = GovukComponent::StartButtonComponent::BUTTON_ATTRIBUTES
+    html_options = GovukComponent::StartButtonComponent::LINK_ATTRIBUTES
       .merge build_html_options(extra_options, style: :button)
 
     if block_given?

--- a/guide/content/components/start-button.slim
+++ b/guide/content/components/start-button.slim
@@ -12,4 +12,22 @@ p
   caption: "Start button",
   code: start_button_normal)
 
+== render('/partials/example.*',
+  caption: "Rendering a start button in a form",
+  code: start_button_as_button) do
+
+  markdown:
+    If you need to submit data you can make the component render a form
+    containing a button instead of a link by passing `as_button: true`. This
+    approach uses the Rails `button_to` helper and will render a form that
+    will `POST` to the target URL.
+
+  div.govuk-warning-text
+    span.govuk-warning-text__icon aria-hidden="true"
+      | !
+    strong.govuk-warning-text__text
+      span.govuk-warning-text__assistive Warning
+      | The GOV.UK Design system
+      =< link_to("advises against submitting data with a start button", "https://design-system.service.gov.uk/components/button/#start-buttons").html_safe
+
 == render('/partials/related-info.*', links: start_button_info)

--- a/guide/lib/examples/start_button_helpers.rb
+++ b/guide/lib/examples/start_button_helpers.rb
@@ -5,5 +5,11 @@ module Examples
         = govuk_start_button(text: "Start now", href: "#")
       START_BUTTON
     end
+
+    def start_button_as_button
+      <<~START_BUTTON
+        = govuk_start_button(text: "Start now", href: "#", as_button: true)
+      START_BUTTON
+    end
   end
 end

--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -11,6 +11,10 @@ module Helpers
     def variants
       []
     end
+
+    def protect_against_forgery?
+      false
+    end
   end
 
   module Formatters

--- a/spec/components/govuk_component/start_button_component_spec.rb
+++ b/spec/components/govuk_component/start_button_component_spec.rb
@@ -4,31 +4,66 @@ RSpec.describe(GovukComponent::StartButtonComponent, type: :component) do
   let(:component_css_class) { 'govuk-button--start' }
   let(:text) { 'Department for Education' }
   let(:href) { 'https://www.gov.uk/government/organisations/department-for-education' }
-  let(:kwargs) { { text: text, href: href } }
+  let(:as_button) { false }
+  let(:kwargs) { { text: text, href: href, as_button: as_button } }
+
+  before do
+    allow_any_instance_of(GovukComponent::StartButtonComponent)
+      .to(receive(:protect_against_forgery?).and_return(false))
+  end
 
   subject! { render_inline(GovukComponent::StartButtonComponent.new(**kwargs)) }
 
-  specify 'renders a link element with the right text and href' do
-    expected_classes = %w(govuk-button govuk-button--start)
-    expect(rendered_content).to have_tag('a', text: text, with: { class: expected_classes })
-  end
-
-  specify 'the link contains an SVG chevron' do
-    expect(rendered_content).to have_tag('a') do
-      with_tag('svg', with: { 'aria-hidden' => true }) { with_tag('path') }
+  context 'as a link' do
+    specify 'renders a link element with the right text and href' do
+      expected_classes = %w(govuk-button govuk-button--start)
+      expect(rendered_content).to have_tag('a', text: text, with: { class: expected_classes })
     end
+
+    specify 'the link contains an SVG chevron' do
+      expect(rendered_content).to have_tag('a') do
+        with_tag('svg', with: { 'aria-hidden' => true }) { with_tag('path') }
+      end
+    end
+
+    specify 'the link has the right attributes' do
+      expected_attributes = {
+        'data-module' => 'govuk-button',
+        'role' => 'button',
+        'draggable' => 'false'
+      }
+
+      expect(rendered_content).to have_tag('a', with: expected_attributes)
+    end
+
+    it_behaves_like 'a component that accepts custom classes'
+    it_behaves_like 'a component that accepts custom HTML attributes'
   end
 
-  specify 'the link has the right attributes' do
-    expected_attributes = {
-      'data-module' => 'govuk-button',
-      'role' => 'button',
-      'draggable' => 'false'
-    }
+  context 'as a button' do
+    let(:as_button) { true }
 
-    expect(rendered_content).to have_tag('a', with: expected_attributes)
+    specify 'renders a button element with the right text and href' do
+      expected_classes = %w(govuk-button govuk-button--start)
+      expect(rendered_content).to have_tag('button', text: text, with: { class: expected_classes })
+    end
+
+    specify 'the link contains an SVG chevron' do
+      expect(rendered_content).to have_tag('button') do
+        with_tag('svg', with: { 'aria-hidden' => true }) { with_tag('path') }
+      end
+    end
+
+    specify 'the link has the right attributes' do
+      expected_attributes = {
+        'data-module' => 'govuk-button',
+        'draggable' => 'false'
+      }
+
+      expect(rendered_content).to have_tag('button', with: expected_attributes)
+    end
+
+    it_behaves_like 'a component that accepts custom classes'
+    it_behaves_like 'a component that accepts custom HTML attributes'
   end
-
-  it_behaves_like 'a component that accepts custom classes'
-  it_behaves_like 'a component that accepts custom HTML attributes'
 end

--- a/spec/components/shared/a_component_that_accepts_custom_html_attributes.rb
+++ b/spec/components/shared/a_component_that_accepts_custom_html_attributes.rb
@@ -11,11 +11,9 @@ shared_examples 'a component that accepts custom HTML attributes' do
   context 'classes' do
     let(:custom_class) { 'red-and-yellow-stripes' }
     let(:updated_kwargs) { kwargs.deep_merge({ html_attributes: { class: Array.wrap(custom_class) } }) }
-    let(:actual_classes) { html.at('/*[1]').attr('class').split }
 
     specify 'the custom class is merged with the default ones' do
-      expect(actual_classes).to include(custom_class)
-      expect(actual_classes).to include(component_css_class)
+      expect(rendered_content).to have_tag('*', with: { class: [custom_class, component_css_class] })
     end
   end
 end


### PR DESCRIPTION
There are certain situations where the start button should submit a form rather than taking the user to a new location. Effectively, this should render using `button_to` instead of `link_to`.

Idea came from this comment: https://github.com/DFE-Digital/apply-for-qualified-teacher-status/pull/174#discussion_r910155776

I can't get the tests to pass at the moment, something to do with them depending on the view context helpers, but I'm not familiar with view components.