### PR TITLE
Add support for array of `meta_item` hashes in `GovukComponent::FooterComponent`

### DIFF
--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -65,9 +65,14 @@ private
   def build_meta_links(links)
     return [] if links.blank?
 
-    fail(ArgumentError, 'meta links must be a hash') unless links.is_a?(Hash)
-
-    links.map { |text, href| raw(link_to(text, href, class: %w(govuk-footer__link))) }
+    case links
+    when Array
+      links.map { |link| raw(link_to(link[:text], link[:href], class: %w(govuk-footer__link), **link.fetch(:attr, {}))) }
+    when Hash
+      links.map { |text, href| raw(link_to(text, href, class: %w(govuk-footer__link))) }
+    else
+      fail(ArgumentError, 'meta links must be a hash') unless links.is_a?(Hash)
+    end
   end
 
   def default_licence

--- a/guide/content/components/footer.slim
+++ b/guide/content/components/footer.slim
@@ -22,6 +22,16 @@ p The footer provides copyright, licensing and other information about your
     and contact details in the footer:
 
 == render('/partials/example.*',
+  caption: "Footer with meta links that have custom HTML attributes",
+  code: footer_with_meta_items,
+  data: footer_meta_complex_items) do
+
+  markdown:
+    If you need greater control of the meta links you can
+    provide them as an array of hashes with the keys `text:`, `href:` and `attr:` where
+    attr is a hash of HTML attributes.
+
+== render('/partials/example.*',
   caption: "Footer with custom content beneath the licence information",
   code: footer_with_custom_meta_html) do
 

--- a/guide/lib/examples/footer_helpers.rb
+++ b/guide/lib/examples/footer_helpers.rb
@@ -18,6 +18,19 @@ module Examples
       FOOTER_META_ITEMS
     end
 
+    def footer_meta_complex_items
+      <<~FOOTER_META_ITEMS
+        {
+          meta_items: [
+            { text: "Apricot", href: "#apr", attr: { data: { controller: "item-a" } } },
+            { text: "Blackberry", href: "#blb", attr: { data: { controller: "item-b" } } },
+            { text: "Cherry", href: "#chy", attr: { rel: "noopener" } },
+            { text: "Damson", href: "#dsn", attr: { aria: { description: "An edible subspecies of plum" } } },
+          ]
+        }
+      FOOTER_META_ITEMS
+    end
+
     def footer_with_custom_meta_html
       <<~FOOTER_META_HTML
         = render GovukComponent::FooterComponent.new do |footer|

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -83,6 +83,31 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
           end
         end
       end
+
+      context "when meta items are provided as an array of hashes" do
+        let(:meta_items) do
+          [
+            { text: "One", href: "/one", attr: { a: "one" } },
+            { text: "Two", href: "/two", attr: { b: "two" } },
+            { text: "Three", href: "/two" }
+          ]
+        end
+        let(:kwargs) { { meta_items_title: heading_text, meta_items: meta_items } }
+
+        specify "each meta item is rendered" do
+          expect(rendered_content).to have_tag(selector) do
+            with_tag("li > a", count: meta_items.size)
+
+            meta_items.each do |item|
+              with_tag("li", with: { class: "govuk-footer__inline-list-item" }) do
+                expected_attributes = { href: item[:href] }.merge(item.fetch(:attr, {}))
+
+                with_tag("a", with: expected_attributes, text: item[:text])
+              end
+            end
+          end
+        end
+      end
     end
 
     describe "custom meta_licence text" do


### PR DESCRIPTION
The original implementation of meta items wasn't feature complete with the GOV.UK original in that it took a hash of `{ text: href }` style meta items.

[The GOV.UK frontend version instead takes an array of hashes](https://design-system.service.gov.uk/components/footer/) `[ { href:, text:, attr: } ]` It's wordier but more powerful as it allows custom attributes to be set for each link.

This PR adds support for original format in addition to the condensed one.

Refs #348

## Final tasks

* [x] Add an example to the guide
* [x] Fix the test coverage (the else branch in the case statement isn't covered in the specs)
