### PR TITLE
Improve test coverage

### DIFF
--- a/app/components/govuk_component/breadcrumbs_component.rb
+++ b/app/components/govuk_component/breadcrumbs_component.rb
@@ -28,7 +28,7 @@ private
     when Hash
       breadcrumbs.map { |text, link| build_list_item(text, link) }
     else
-      fail(ArgumentError, "breadcrumb must be an array or hash")
+      fail(ArgumentError, "breadcrumbs must be an array or hash")
     end
   end
 

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -71,7 +71,7 @@ private
     when Hash
       links.map { |text, href| raw(link_to(text, href, class: %w(govuk-footer__link))) }
     else
-      fail(ArgumentError, 'meta links must be a hash') unless links.is_a?(Hash)
+      fail(ArgumentError, 'meta links must be a hash or array of hashes') unless links.is_a?(Hash)
     end
   end
 

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -105,6 +105,7 @@ private
 
     def active?
       return @active_override unless @active_override.nil?
+      return false if href.blank?
 
       current_page?(href)
     end

--- a/spec/components/govuk_component/breadcrumbs_component_spec.rb
+++ b/spec/components/govuk_component/breadcrumbs_component_spec.rb
@@ -40,6 +40,12 @@ RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
     end
   end
 
+  context 'when an invalid breadcrumbs object is provided' do
+    specify "raises an error" do
+      expect { GovukComponent::BreadcrumbsComponent.new(breadcrumbs: "invalid") }.to raise_error(ArgumentError, "breadcrumbs must be an array or hash")
+    end
+  end
+
   specify 'breadcrumbs links are correct' do
     breadcrumbs.reject { |_, path| path.nil? }.each do |name, path|
       expect(rendered_content).to have_tag('li > a', with: { class: 'govuk-breadcrumbs__link', href: path }, text: name)

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -108,6 +108,12 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
           end
         end
       end
+
+      context "when invalid meta items are provided" do
+        specify "raises an error" do
+          expect { GovukComponent::FooterComponent.new(meta_items: "invalid") }.to raise_error(ArgumentError, "meta links must be a hash or array of hashes")
+        end
+      end
     end
 
     describe "custom meta_licence text" do

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -188,7 +188,8 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
           { text: 'Item 1', href: '/item-1' },
           { text: 'Item 2', href: '/item-2', active: true },
           { text: 'Item 3', href: '/item-3' },
-          { text: 'Item 4', href: '/item-4', options: { method: :delete } }
+          { text: 'Item 4', href: '/item-4', options: { method: :delete } },
+          { text: 'Item 5' }
         ]
       end
 
@@ -204,8 +205,25 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
       end
 
       specify 'nav contains the right number of items' do
+        expect(rendered_content).to have_tag("li", with: { class: "govuk-header__navigation-item" }, count: navigation_items.count)
+      end
+
+      specify 'the naviation items with a href present are rendered as links' do
         expect(rendered_content).to have_tag('nav') do
-          with_tag('a', with: { class: 'govuk-header__link' }, count: navigation_items.size)
+          navigation_items.select { |ni| ni.key?(:href) }.each do |item|
+            with_tag('li', with: { class: 'govuk-header__navigation-item' }) do
+              with_tag('a', with: { class: 'govuk-header__link' }, text: item[:text])
+            end
+          end
+        end
+      end
+
+      specify 'the naviation items without a href present are rendered as text' do
+        expect(rendered_content).to have_tag('nav') do
+          navigation_items.reject { |ni| ni.key?(:href) }.each do |item|
+            with_tag('li', with: { class: 'govuk-header__navigation-item' }, text: item[:text])
+            without_tag("a", text: item[:text])
+          end
         end
       end
 
@@ -225,11 +243,13 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
       specify 'nav items have the right text and links' do
         expect(rendered_content).to have_tag('nav') do
-          navigation_items.each do |link|
-            if link.key?(:options)
-              with_tag('a', with: { href: link.fetch(:href), "data-method": link.dig(:options, :method) }, text: link.fetch(:text))
+          navigation_items.each do |item|
+            if item.key?(:options)
+              with_tag('a', with: { href: item.fetch(:href), "data-method": item.dig(:options, :method) }, text: item.fetch(:text))
+            elsif item.key?(:href)
+              with_tag('a', with: { href: item.fetch(:href) }, text: item.fetch(:text))
             else
-              with_tag('a', with: { href: link.fetch(:href) }, text: link.fetch(:text))
+              with_tag('li', text: item.fetch(:text))
             end
           end
         end


### PR DESCRIPTION
There were a few spots where test coverage wasn't 100%, mostly not testing appropriate errors are raised when invalid collection objects are passed in.

- Add a spec when header items don't have a href
- Add spec covering invalid footer meta items object
- Add spec covering handling of invalid breadcrumbs
