### PR TITLE
Make footer component configurable

### DIFF
--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -11,13 +11,13 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     classes: [],
     container_classes: [],
     container_html_attributes: {},
-    copyright_text: default_copright_text,
-    copyright_url: default_copyright_url,
+    copyright_text: Govuk::Components.config.default_footer_component_copyright_text,
+    copyright_url: Govuk::Components.config.default_footer_component_copyright_url,
     html_attributes: {},
     meta_items: {},
     meta_items_title: "Support links",
     meta_licence: nil,
-    meta_text: nil,
+    meta_text: Govuk::Components.config.default_footer_component_meta_text,
     meta_classes: [],
     meta_html_attributes: {}
   )
@@ -83,13 +83,5 @@ private
 
   def build_copyright(text, url)
     link_to(text, url, class: %w(govuk-footer__link govuk-footer__copyright-logo))
-  end
-
-  def default_copright_text
-    raw(%(© Crown copyright))
-  end
-
-  def default_copyright_url
-    "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
   end
 end

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -32,6 +32,9 @@ module Govuk
       default_back_link_component_text: 'Back',
       default_header_component_navigation_label: 'Navigation menu',
       default_header_component_menu_button_label: 'Show or hide navigation menu',
+      default_footer_component_meta_text: nil,
+      default_footer_component_copyright_text: '© Crown copyright',
+      default_footer_component_copyright_url: "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/",
     }.freeze
 
     DEFAULTS.each_key { |k| config_accessor(k) { DEFAULTS[k] } }

--- a/spec/components/govuk_component/configuration/footer_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/footer_component_configuration_spec.rb
@@ -1,0 +1,51 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::FooterComponent, type: :component) do
+  let(:selector) { "footer.govuk-footer .govuk-width-container .govuk-footer__meta" }
+  let(:kwargs) { {} }
+
+  describe 'configuration' do
+    after { Govuk::Components.reset! }
+
+    describe 'default footer component text and url' do
+      let(:overridden_default_text) { '© Not copyrighted' }
+      let(:overridden_default_url) { 'www.gov.uk' }
+
+      before do
+        Govuk::Components.configure do |config|
+          config.default_footer_component_copyright_text = overridden_default_text
+          config.default_footer_component_copyright_url = overridden_default_url
+        end
+      end
+
+      subject! { render_inline(GovukComponent::FooterComponent.new(**kwargs)) }
+
+      specify 'renders the component with overriden default text and url' do
+        expect(rendered_content).to have_tag(selector) do
+          with_tag("div", with: { class: "govuk-footer__meta-item" }, text: overridden_default_text)
+          with_tag("a", text: overridden_default_text, with: { href: overridden_default_url })
+        end
+      end
+    end
+
+    describe 'default_footer_component_meta_text' do
+      let(:overridden_default_text) { 'some meta text' }
+
+      before do
+        Govuk::Components.configure do |config|
+          config.default_footer_component_meta_text = overridden_default_text
+        end
+      end
+
+      subject! { render_inline(GovukComponent::FooterComponent.new(meta_text: overridden_default_text)) }
+
+      specify "custom text is rendered" do
+        expect(rendered_content).to have_tag(
+          "div",
+          with: { class: "govuk-footer__meta-custom" },
+          text: Regexp.new(overridden_default_text)
+        )
+      end
+    end
+  end
+end


### PR DESCRIPTION
Building on https://github.com/DFE-Digital/govuk-components/pull/355/, this pr allows the meta_text, copyright_text and copyright_url attributes of the footer component to be configurable