### PR TITLE
Make breadcrumbs component configurable

### DIFF
--- a/app/components/govuk_component/breadcrumbs_component.rb
+++ b/app/components/govuk_component/breadcrumbs_component.rb
@@ -1,7 +1,12 @@
 class GovukComponent::BreadcrumbsComponent < GovukComponent::Base
   attr_reader :breadcrumbs, :hide_in_print, :collapse_on_mobile
 
-  def initialize(breadcrumbs:, hide_in_print: false, collapse_on_mobile: false, classes: [], html_attributes: {})
+  def initialize(breadcrumbs:,
+                 hide_in_print: Govuk::Components.config.default_breadcrumbs_component_hide_in_print,
+                 collapse_on_mobile: Govuk::Components.config.default_breadcrumbs_component_collapse_on_mobile,
+                 classes: [],
+                 html_attributes: {})
+
     @breadcrumbs        = build_list(breadcrumbs)
     @hide_in_print      = hide_in_print
     @collapse_on_mobile = collapse_on_mobile

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -30,6 +30,8 @@ module Govuk
 
     DEFAULTS = {
       default_back_link_component_text: 'Back',
+      default_breadcrumbs_component_collapse_on_mobile: false,
+      default_breadcrumbs_component_hide_in_print: false,
       default_header_component_navigation_label: 'Navigation menu',
       default_header_component_menu_button_label: 'Show or hide navigation menu',
       default_footer_component_meta_text: nil,

--- a/spec/components/govuk_component/configuration/breadcrumbs_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/breadcrumbs_component_configuration_spec.rb
@@ -1,0 +1,57 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::BreadcrumbsComponent, type: :component) do
+  let(:href) { 'https://www.gov.uk/government/organisations/department-for-education' }
+  let(:link_text) { 'Organisations' }
+  let(:breadcrumbs) { { link_text => href } }
+  let(:kwargs) { { breadcrumbs: breadcrumbs } }
+  let(:component_css_class) { 'govuk-breadcrumbs' }
+
+  describe 'configuration' do
+    after { Govuk::Components.reset! }
+
+    describe 'default_breadcrumbs_collapse_on_mobile_value' do
+      let(:overridden_default_collapse_on_mobile) { true }
+      let(:collapse_on_mobile_css_class) { 'govuk-breadcrumbs--collapse-on-mobile' }
+
+      before do
+        Govuk::Components.configure do |config|
+          config.default_breadcrumbs_component_collapse_on_mobile = overridden_default_collapse_on_mobile
+        end
+      end
+
+      subject! { render_inline(GovukComponent::BreadcrumbsComponent.new(**kwargs)) }
+
+      specify 'renders the component with the correct class' do
+        expect(rendered_content).to have_tag(
+          'div',
+          with: { class: [component_css_class, collapse_on_mobile_css_class] },
+        ) do
+          with_tag('a', text: link_text, with: { href: href })
+        end
+      end
+    end
+
+    describe 'default_breadcrumbs_hide_in_print_value' do
+      let(:hide_in_print_css_class) { 'govuk-\!-display-none-print' }
+      let(:overridden_default_hide_in_print) { true }
+
+      before do
+        Govuk::Components.configure do |config|
+          config.default_breadcrumbs_component_hide_in_print = overridden_default_hide_in_print
+        end
+      end
+
+      subject! { render_inline(GovukComponent::BreadcrumbsComponent.new(**kwargs)) }
+
+      specify 'renders the component with the correct class' do
+        expect(rendered_content).to have_tag(
+          'div',
+          with: { class: [component_css_class, hide_in_print_css_class] },
+        ) do
+          with_tag('a', text: link_text, with: { href: href })
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR allows `hide_in_print` and `collapse_on_mobile` in the breadcrumbs component to be configurable.