### PR TITLE
Make phase banner configurable

### DIFF
--- a/app/components/govuk_component/phase_banner_component.rb
+++ b/app/components/govuk_component/phase_banner_component.rb
@@ -1,7 +1,12 @@
 class GovukComponent::PhaseBannerComponent < GovukComponent::Base
   attr_reader :text, :phase_tag
 
-  def initialize(tag: nil, text: nil, classes: [], html_attributes: {})
+  def initialize(
+    tag: { text: Govuk::Components.config.default_phase_banner_component_tag },
+    text: Govuk::Components.config.default_phase_banner_component_text,
+    classes: [],
+    html_attributes: {}
+  )
     @phase_tag = tag
     @text      = text
 

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -39,6 +39,8 @@ module Govuk
       default_footer_component_meta_text: nil,
       default_footer_component_copyright_text: '© Crown copyright',
       default_footer_component_copyright_url: "https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/",
+      default_phase_banner_component_tag: nil,
+      default_phase_banner_component_text: nil,
       default_tag_component_colour: nil,
     }.freeze
 

--- a/spec/components/govuk_component/configuration/phase_banner_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/phase_banner_component_configuration_spec.rb
@@ -1,0 +1,30 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::PhaseBannerComponent, type: :component) do
+  describe "configuration" do
+    after { Govuk::Components.reset! }
+
+    describe 'default phase banner component tag and text' do
+      let(:overridden_default_tag) { 'Beta' }
+      let(:overridden_default_text) { 'Public service' }
+
+      before do
+        Govuk::Components.configure do |config|
+          config.default_phase_banner_component_tag = overridden_default_tag
+          config.default_phase_banner_component_text = overridden_default_text
+        end
+      end
+
+      subject! { render_inline(GovukComponent::PhaseBannerComponent.new) }
+
+      specify "renders div element with the overridden text and banner tag" do
+        expect(rendered_content).to have_tag("div", with: { class: "govuk-phase-banner" }) do
+          with_tag("p", with: { class: "govuk-phase-banner__content" }) do
+            with_tag("strong", text: overridden_default_tag, with: { class: "govuk-phase-banner__content__tag" })
+            with_tag("span", text: overridden_default_text, with: { class: "govuk-phase-banner__text" })
+          end
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Allows the tag and text attributes of the phase banner component to be configurable