### PR TITLE
Support links opening in new tab

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -1,4 +1,8 @@
+require "html_attributes_utils"
+
 module GovukLinkHelper
+  using HTMLAttributesUtils
+
   LINK_STYLES = {
     inverse:          "govuk-link--inverse",
     muted:            "govuk-link--muted",
@@ -95,10 +99,11 @@ private
   def build_html_options(provided_options, style: :link, new_tab: false)
     element_styles = { link: LINK_STYLES, button: BUTTON_STYLES }.fetch(style, {})
 
-    remaining_options = {
-      **remove_styles_from_provided_options(element_styles, provided_options),
-      **new_tab_options(new_tab)
-    }
+    # we need to take a couple of extra steps here because we don't want the style
+    # params (inverse, muted, etc) to end up as extra attributes on the link.
+
+    remaining_options = new_tab_options(new_tab)
+      .deep_merge_html_attributes(remove_styles_from_provided_options(element_styles, provided_options))
 
     style_classes = build_style_classes(style, extract_styles_from_provided_options(element_styles, provided_options))
 

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -149,6 +149,8 @@ private
 
     new_tab_text = new_tab.is_a?(String) ? new_tab : Govuk::Components.config.default_link_new_tab_text
 
+    return text if new_tab_text.blank?
+
     %(#{text} #{new_tab_text})
   end
 end

--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -41,7 +41,7 @@ module GovukLinkHelper
     if block_given?
       link_to(name, html_options, &block)
     else
-      link_to(name, options, html_options)
+      link_to(prepare_link_text(name, new_tab), options, html_options)
     end
   end
 
@@ -75,7 +75,7 @@ module GovukLinkHelper
     if block_given?
       link_to(name, html_options, &block)
     else
-      link_to(name, options, html_options)
+      link_to(prepare_link_text(name, new_tab), options, html_options)
     end
   end
 
@@ -137,6 +137,14 @@ private
     return {} if provided_options.blank?
 
     provided_options&.except(*styles.keys)
+  end
+
+  def prepare_link_text(text, new_tab)
+    return text unless new_tab
+
+    new_tab_text = new_tab.is_a?(String) ? new_tab : Govuk::Components.config.default_link_new_tab_text
+
+    %(#{text} #{new_tab_text})
   end
 end
 

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  spec.add_dependency("html-attributes-utils", "~> 0.9", ">= 0.9.2")
+  spec.add_dependency("html-attributes-utils", "~> 1.0.0", ">= 1.0.0")
   spec.add_dependency("pagy", "~> 6.0")
   spec.add_dependency "view_component", "~> 2.74.1"
 

--- a/guide/lib/examples/link_helpers.rb
+++ b/guide/lib/examples/link_helpers.rb
@@ -5,23 +5,23 @@ module Examples
     end
 
     def govuk_link_to_inverse
-      %(= govuk_link_to 'An inverse hyperlink', '#', inverse: true)
+      %(= govuk_link_to('An inverse hyperlink', '#', { inverse: true }))
     end
 
     def govuk_link_to_muted
-      %(= govuk_link_to 'A muted hyperlink', '#', muted: true)
+      %(= govuk_link_to('A muted hyperlink', '#', { muted: true }))
     end
 
     def govuk_link_other_styles
       <<~LINKS
         p
-          = govuk_link_to 'A hyperlink without an underline', '#', no_underline: true
+          = govuk_link_to('A hyperlink without an underline', '#', { no_underline: true })
 
         p
-          = govuk_link_to 'A hyperlink without a visited state', '#', no_visited_state: true
+          = govuk_link_to('A hyperlink without a visited state', '#', { no_visited_state: true })
 
         p
-          = govuk_link_to 'A text-coloured hyperlink', '#', text_colour: true
+          = govuk_link_to('A text-coloured hyperlink', '#', { text_colour: true })
       LINKS
     end
 
@@ -36,9 +36,9 @@ module Examples
     def govuk_button_other_styles
       <<~BUTTONS
         .govuk-button-group
-          = govuk_button_link_to 'A disabled button', '#', disabled: true
-          = govuk_button_link_to 'A secondary button', '#', secondary: true
-          = govuk_button_link_to 'A warning button', '#', warning: true
+          = govuk_button_link_to('A disabled button', '#', { disabled: true })
+          = govuk_button_link_to('A secondary button', '#', { secondary: true })
+          = govuk_button_link_to('A warning button', '#', { warning: true })
       BUTTONS
     end
 

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -96,6 +96,8 @@ module Govuk
       default_warning_text_icon_fallback_text: "Warning",
       default_warning_text_icon: "!",
 
+      default_link_new_tab_text: "(opens in new tab)",
+
       require_summary_list_action_visually_hidden_text: false,
     }.freeze
 

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -66,14 +66,23 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
   describe "#govuk_link_to" do
     let(:link_text) { 'Onwards!' }
     let(:link_url) { '/some/link' }
+    let(:link_params) { { controller: :some_controller, action: :some_action } }
 
     before do
       allow(self).to receive(:url_for).with(link_params).and_return(link_url)
     end
 
-    context "when provided with link text and url params" do
-      let(:link_params) { { controller: :some_controller, action: :some_action } }
+    context "when provided with a path instead of params" do
+      let(:path) { "/some/path" }
+      before { allow(self).to receive(:url_for).with(path).and_return(path) }
+      subject { govuk_link_to(path) { link_text } }
 
+      specify "renders a link with the given path" do
+        expect(subject).to have_tag("a", with: { href: path, class: "govuk-link" }, text: link_text)
+      end
+    end
+
+    context "when provided with link text and url params" do
       subject { govuk_link_to link_text, link_params }
 
       it { is_expected.to have_tag('a', text: link_text, with: { href: link_url, class: 'govuk-link' }) }
@@ -81,7 +90,6 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
     context "when provided with url params and the block" do
       let(:link_html) { tag.span(link_text) }
-      let(:link_params) { { controller: :some_controller, action: :some_action } }
 
       subject { govuk_link_to(link_params) { link_html } }
 
@@ -89,7 +97,6 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     end
 
     context "customising the GOV.UK link style" do
-      let(:link_params) { { controller: :some_controller, action: :some_action } }
       let(:custom_html_options) { { inverse: true } }
 
       subject { govuk_link_to(link_text, link_params, custom_html_options) }
@@ -98,7 +105,6 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     end
 
     context "adding custom classes" do
-      let(:link_params) { { controller: :some_controller, action: :some_action } }
       let(:custom_class) { { class: "green" } }
 
       subject { govuk_link_to(link_text, link_params, { class: "green", no_underline: true }) }
@@ -106,9 +112,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       it { is_expected.to have_tag('a', with: { href: link_url, class: %w(green govuk-link--no-underline) }, text: link_text) }
     end
 
-    describe "opening links in new windows" do
-      let(:link_params) { { controller: :some_controller, action: :some_action } }
-
+    describe "opening links in new tabs" do
       context "when new_tab: true" do
         let(:default_new_tab_text) { "(opens in new tab)" }
         subject { govuk_link_to(link_text, link_params, new_tab: true) }
@@ -121,6 +125,15 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
         subject { govuk_link_to(link_text, link_params, new_tab: overridden_new_tab_text) }
 
         it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: "#{link_text} #{overridden_new_tab_text}") }
+      end
+
+      context "when new_tab is an empty string" do
+        let(:overridden_new_tab_text) { "" }
+        subject { govuk_link_to(link_text, link_params, new_tab: overridden_new_tab_text) }
+
+        it "appends nothing to the string" do
+          expect(subject).to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: link_text)
+        end
       end
 
       context "when custom 'rel' and 'target' values are provided" do
@@ -239,9 +252,14 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
   describe "#govuk_button_link_to" do
     let(:button_link_text) { 'Activate!' }
     let(:button_link_url) { '/another/link' }
+    let(:link_params) { { controller: :some_controller, action: :some_action } }
+
+    before do
+      allow(self).to receive(:url_for).with(link_params).and_return(button_link_url)
+    end
 
     context "when provided with button text and url params" do
-      subject { govuk_button_link_to(button_link_text, button_link_url) }
+      subject { govuk_button_link_to(button_link_text, link_params) }
 
       specify "renders a link styled as a button with the correct attributes" do
         expect(subject).to have_tag(
@@ -258,10 +276,20 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       end
     end
 
+    context "when provided with a path instead of params" do
+      let(:path) { "/some/path" }
+      before { allow(self).to receive(:url_for).with(path).and_return(path) }
+      subject { govuk_button_link_to(path) { button_link_text } }
+
+      specify "renders a link with the given path" do
+        expect(subject).to have_tag("a", with: { href: path, class: "govuk-button" }, text: button_link_text)
+      end
+    end
+
     context "when provided with url params and a block" do
       let(:button_html) { tag.span(button_text) }
 
-      subject { govuk_button_link_to(button_link_url) { button_link_text } }
+      subject { govuk_button_link_to(link_params) { button_link_text } }
 
       specify "renders a link styled as a button with the correct attributes" do
         expect(subject).to have_tag("a", with: { href: button_link_url, class: "govuk-button" }, text: button_link_text)
@@ -271,7 +299,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     context "customising the GOV.UK button style" do
       let(:custom_link_button_options) { { secondary: true } }
 
-      subject { govuk_button_link_to(button_link_text, button_link_url, custom_link_button_options) }
+      subject { govuk_button_link_to(button_link_text, link_params, custom_link_button_options) }
 
       specify "renders a form with an button that has the GOV.UK modifier classes" do
         expect(subject).to have_tag("a", with: { href: button_link_url, class: %w(govuk-button govuk-button--secondary) }, text: button_link_text)
@@ -279,30 +307,51 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     end
 
     context "adding custom classes" do
-      subject { govuk_button_link_to(button_link_text, button_link_url, { class: "yellow", disabled: true }) }
+      subject { govuk_button_link_to(button_link_text, link_params, { class: "yellow", disabled: true }) }
 
       specify "renders a form with an button that has the custom classes" do
         expect(subject).to have_tag("a", with: { href: button_link_url, class: %w(govuk-button yellow) }, text: button_link_text)
       end
     end
 
-    describe "opening links in new windows" do
+    describe "opening links in new tabs" do
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+
       context "when new_tab: true" do
         let(:default_new_tab_text) { "(opens in new tab)" }
-        let(:link_params) { { controller: :some_controller, action: :some_action } }
-
-        subject { govuk_button_link_to(button_link_text, button_link_url, new_tab: true) }
+        subject { govuk_button_link_to(button_link_text, link_params, new_tab: true) }
 
         it { is_expected.to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: "#{button_link_text} #{default_new_tab_text}") }
       end
 
       context "when new_tab: '(opens in new window)'" do
         let(:overridden_new_tab_text) { "(opens in new window)" }
-        let(:link_params) { { controller: :some_controller, action: :some_action } }
-
-        subject { govuk_button_link_to(button_link_text, button_link_url, new_tab: overridden_new_tab_text) }
+        subject { govuk_button_link_to(button_link_text, link_params, new_tab: overridden_new_tab_text) }
 
         it { is_expected.to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: "#{button_link_text} #{overridden_new_tab_text}") }
+      end
+
+      context "when new_tab is an empty string" do
+        let(:overridden_new_tab_text) { "" }
+        subject { govuk_button_link_to(button_link_text, link_params, new_tab: overridden_new_tab_text) }
+
+        it "appends nothing to the string" do
+          expect(subject).to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: button_link_text)
+        end
+      end
+
+      context "when custom 'rel' and 'target' values are provided" do
+        let(:custom_rel) { { rel: "help" } }
+        let(:custom_target) { { target: "new" } }
+        subject { govuk_button_link_to(button_link_text, link_params, { **custom_rel, **custom_target }, new_tab: true) }
+
+        it "replaces the default target value with the provided one" do
+          expect(subject).to have_tag('a', with: { rel: "noreferrer noopener help" })
+        end
+
+        it "appends the provided rel value to 'noreferrer' and 'noopener'" do
+          expect(subject).to have_tag('a', with: { target: 'new' })
+        end
       end
     end
   end

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -107,10 +107,10 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     end
 
     describe "opening links in new windows" do
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+
       context "when new_tab: true" do
         let(:default_new_tab_text) { "(opens in new tab)" }
-        let(:link_params) { { controller: :some_controller, action: :some_action } }
-
         subject { govuk_link_to(link_text, link_params, new_tab: true) }
 
         it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: "#{link_text} #{default_new_tab_text}") }
@@ -118,11 +118,23 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       context "when new_tab: '(opens in new window)'" do
         let(:overridden_new_tab_text) { "(opens in new window)" }
-        let(:link_params) { { controller: :some_controller, action: :some_action } }
-
         subject { govuk_link_to(link_text, link_params, new_tab: overridden_new_tab_text) }
 
         it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: "#{link_text} #{overridden_new_tab_text}") }
+      end
+
+      context "when custom 'rel' and 'target' values are provided" do
+        let(:custom_rel) { { rel: "help" } }
+        let(:custom_target) { { target: "new" } }
+        subject { govuk_link_to(link_text, link_params, { **custom_rel, **custom_target }, new_tab: true) }
+
+        it "replaces the default target value with the provided one" do
+          expect(subject).to have_tag('a', with: { rel: "noreferrer noopener help" })
+        end
+
+        it "appends the provided rel value to 'noreferrer' and 'noopener'" do
+          expect(subject).to have_tag('a', with: { target: 'new' })
+        end
       end
     end
   end

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -105,6 +105,14 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       it { is_expected.to have_tag('a', with: { href: link_url, class: %w(green govuk-link--no-underline) }, text: link_text) }
     end
+
+    context "when new_tab: true" do
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+
+      subject { govuk_link_to(link_text, link_params, new_tab: true) }
+
+      it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: link_text) }
+    end
   end
 
   describe "#govuk_mail_to" do
@@ -205,60 +213,61 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
   end
 
   describe "#govuk_button_link_to" do
-    let(:button_text) { 'Do something' }
-    let(:button_url) { '/some/action' }
-    let(:button_params) { { controller: :some_controller, action: :some_action } }
-
-    before do
-      allow(self).to receive(:url_for).with(button_params).and_return(button_url)
-    end
+    let(:button_link_text) { 'Activate!' }
+    let(:button_link_url) { '/another/link' }
 
     context "when provided with button text and url params" do
-      subject { govuk_button_link_to(button_text, button_params) }
+      subject { govuk_button_link_to(button_link_text, button_link_url) }
 
       specify "renders a link styled as a button with the correct attributes" do
-        expect(subject).to have_tag("a", with: {
-          href: button_url,
-          class: "govuk-button",
-          draggable: false,
-          role: "button",
-          "data-module": "govuk-button"
-        })
+        expect(subject).to have_tag(
+          "a",
+          with: {
+            href: button_link_url,
+            class: "govuk-button",
+            draggable: false,
+            role: "button",
+            "data-module": "govuk-button"
+          },
+          text: button_link_text
+        )
       end
     end
 
     context "when provided with url params and a block" do
       let(:button_html) { tag.span(button_text) }
 
-      subject { govuk_button_link_to(button_params) { button_html } }
+      subject { govuk_button_link_to(button_link_url) { button_link_text } }
 
       specify "renders a link styled as a button with the correct attributes" do
-        expect(subject).to have_tag("a", with: { href: button_url, class: "govuk-button" }) do
-          with_tag("span", text: button_text)
-        end
+        expect(subject).to have_tag("a", with: { href: button_link_url, class: "govuk-button" }, text: button_link_text)
       end
     end
 
     context "customising the GOV.UK button style" do
-      let(:custom_button_options) { { secondary: true } }
+      let(:custom_link_button_options) { { secondary: true } }
 
-      subject { govuk_button_to(button_text, button_params, custom_button_options) }
+      subject { govuk_button_link_to(button_link_text, button_link_url, custom_link_button_options) }
 
       specify "renders a form with an button that has the GOV.UK modifier classes" do
-        expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("input", with: { type: "submit", class: %w(govuk-button govuk-button--secondary) })
-        end
+        expect(subject).to have_tag("a", with: { href: button_link_url, class: %w(govuk-button govuk-button--secondary) }, text: button_link_text)
       end
     end
 
     context "adding custom classes" do
-      subject { govuk_button_to(button_text, button_params, { class: "yellow", disabled: true }) }
+      subject { govuk_button_link_to(button_link_text, button_link_url, { class: "yellow", disabled: true }) }
 
       specify "renders a form with an button that has the custom classes" do
-        expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("input", with: { type: "submit", class: %w(govuk-button yellow govuk-button--disabled) })
-        end
+        expect(subject).to have_tag("a", with: { href: button_link_url, class: %w(govuk-button yellow) }, text: button_link_text)
       end
+    end
+
+    context "when new_tab: true" do
+      let(:link_params) { { controller: :some_controller, action: :some_action } }
+
+      subject { govuk_button_link_to(button_link_text, button_link_url, new_tab: true) }
+
+      it { is_expected.to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: button_link_text) }
     end
   end
 

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -106,12 +106,24 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       it { is_expected.to have_tag('a', with: { href: link_url, class: %w(green govuk-link--no-underline) }, text: link_text) }
     end
 
-    context "when new_tab: true" do
-      let(:link_params) { { controller: :some_controller, action: :some_action } }
+    describe "opening links in new windows" do
+      context "when new_tab: true" do
+        let(:default_new_tab_text) { "(opens in new tab)" }
+        let(:link_params) { { controller: :some_controller, action: :some_action } }
 
-      subject { govuk_link_to(link_text, link_params, new_tab: true) }
+        subject { govuk_link_to(link_text, link_params, new_tab: true) }
 
-      it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: link_text) }
+        it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: "#{link_text} #{default_new_tab_text}") }
+      end
+
+      context "when new_tab: '(opens in new window)'" do
+        let(:overridden_new_tab_text) { "(opens in new window)" }
+        let(:link_params) { { controller: :some_controller, action: :some_action } }
+
+        subject { govuk_link_to(link_text, link_params, new_tab: overridden_new_tab_text) }
+
+        it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: "#{link_text} #{overridden_new_tab_text}") }
+      end
     end
   end
 
@@ -262,12 +274,24 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       end
     end
 
-    context "when new_tab: true" do
-      let(:link_params) { { controller: :some_controller, action: :some_action } }
+    describe "opening links in new windows" do
+      context "when new_tab: true" do
+        let(:default_new_tab_text) { "(opens in new tab)" }
+        let(:link_params) { { controller: :some_controller, action: :some_action } }
 
-      subject { govuk_button_link_to(button_link_text, button_link_url, new_tab: true) }
+        subject { govuk_button_link_to(button_link_text, button_link_url, new_tab: true) }
 
-      it { is_expected.to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: button_link_text) }
+        it { is_expected.to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: "#{button_link_text} #{default_new_tab_text}") }
+      end
+
+      context "when new_tab: '(opens in new window)'" do
+        let(:overridden_new_tab_text) { "(opens in new window)" }
+        let(:link_params) { { controller: :some_controller, action: :some_action } }
+
+        subject { govuk_button_link_to(button_link_text, button_link_url, new_tab: overridden_new_tab_text) }
+
+        it { is_expected.to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: "#{button_link_text} #{overridden_new_tab_text}") }
+      end
     end
   end
 


### PR DESCRIPTION
This PR adds new keyword argument `new_tab` to `#govuk_link_to` and `#govuk_button_link_to` that makes it easier (and safer) for developers to create links that open in a new tab/window.

The design system specifies that the attributes `rel="noreferrer noopener" target="_blank"` should be present to prevent [reverse tabnabbing](https://owasp.org/www-community/attacks/Reverse_Tabnabbing). This is often forgotten by developers.

The default value for `new_tab` is false. The new behaviours are as follows:

* when `new_tab: false` - no change, the helper works in the normal fashion
* when `new_tab: true` - the default suffix is added after the link text
* when `new_tab: "a string"` - the supplied suffix is added after the link text

The default suffix is "(opens in new tab)".

Fixes #360
