### PR TITLE
When `visually_hidden_text` is omitted from summary list actions, don't render anything

### DIFF
--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -1,18 +1,17 @@
 class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Base
-  class VisuallyHiddenDefaultNilClass < NilClass; end
-
   attr_reader :href, :text, :visually_hidden_text, :attributes, :classes
 
-  def initialize(href: nil, text: 'Change', visually_hidden_text: VisuallyHiddenDefaultNilClass, classes: [], html_attributes: {})
-    if config.require_summary_list_action_visually_hidden_text && visually_hidden_text == VisuallyHiddenDefaultNilClass
+  def initialize(href: nil, text: 'Change', visually_hidden_text: false, classes: [], html_attributes: {})
+    @visually_hidden_text = visually_hidden_text
+
+    if config.require_summary_list_action_visually_hidden_text
       fail(ArgumentError, "missing keyword: visually_hidden_text")
     end
 
     super(classes: classes, html_attributes: html_attributes)
 
-    @href                 = href
-    @text                 = text
-    @visually_hidden_text = visually_hidden_text
+    @href = href
+    @text = text
   end
 
   def render?

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -166,37 +166,65 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
     end
   end
 
-  context "when there is visually hidden text" do
-    subject! do
-      render_inline(described_class.new(**kwargs)) do |component|
-        component.row(classes: "with-visually-hidden-text") do |row|
-          helper.safe_join(
-            [row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/action", text: "Action", visually_hidden_text: "visually hidden")]
-          )
-        end
-
-        component.row(classes: "without-visually-hidden-text") do |row|
-          helper.safe_join(
-            [row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/action", text: "Action", visually_hidden_text: nil)]
-          )
+  describe "visually hidden text" do
+    context "when there is visually hidden text" do
+      subject! do
+        render_inline(described_class.new(**kwargs)) do |component|
+          component.row do |row|
+            helper.safe_join(
+              [row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/action", text: "Action", visually_hidden_text: "visually hidden")]
+            )
+          end
         end
       end
-    end
 
-    specify "renders a span containing visually hidden text separated by a space from the action text" do
-      expect(rendered_content).to have_tag("dl", with: { class: component_css_class }) do
-        with_tag("div", with: { class: %(with-visually-hidden-text govuk-summary-list__row) }) do
-          with_tag("dd", with: { class: "govuk-summary-list__actions" }, text: /Action\s/) do
-            with_tag("a.govuk-link > span", with: { class: "govuk-visually-hidden" })
+      specify "renders a span containing visually hidden text separated by a space from the action text" do
+        expect(rendered_content).to have_tag("dl", with: { class: component_css_class }) do
+          with_tag("div", with: { class: %(govuk-summary-list__row) }) do
+            with_tag("dd", with: { class: "govuk-summary-list__actions" }, text: /Action\s/) do
+              with_tag("a.govuk-link > span", with: { class: "govuk-visually-hidden" })
+            end
           end
         end
       end
     end
 
-    specify "renders no span when there's no visually hidden text" do
-      expect(rendered_content).to have_tag("dl", with: { class: component_css_class }) do
-        with_tag("div", with: { class: %(without-visually-hidden-text govuk-summary-list__row) }) do
-          without_tag("span", with: { class: "govuk-visually-hidden" })
+    context "when visually hidden text is nil" do
+      subject! do
+        render_inline(described_class.new(**kwargs)) do |component|
+          component.row do |row|
+            helper.safe_join(
+              [row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/action", text: "Action", visually_hidden_text: nil)]
+            )
+          end
+        end
+      end
+
+      specify "renders no span when there's no visually hidden text" do
+        expect(rendered_content).to have_tag("dl", with: { class: component_css_class }) do
+          with_tag("div", with: { class: %(govuk-summary-list__row) }) do
+            without_tag("span", with: { class: "govuk-visually-hidden" })
+          end
+        end
+      end
+    end
+
+    context "when visually hidden text param is omitted" do
+      subject! do
+        render_inline(described_class.new(**kwargs)) do |component|
+          component.row do |row|
+            helper.safe_join(
+              [row.key(text: "Key"), row.value(text: "Value"), row.action(href: "/action", text: "Action")]
+            )
+          end
+        end
+      end
+
+      specify "renders no span when there's no visually hidden text" do
+        expect(rendered_content).to have_tag("dl", with: { class: component_css_class }) do
+          with_tag("div", with: { class: %(govuk-summary-list__row) }) do
+            without_tag("span", with: { class: "govuk-visually-hidden" })
+          end
         end
       end
     end


### PR DESCRIPTION
This fixes a bug where when visually_hidden_text is totally omitted the `VisuallyHiddenDefaultNilClass` class name is rendered in the visually hidden span. It turns out you can't simply inherit from `NilClass`.

We can use `false` here instead.
