### PR TITLE
Make `view_component` version less specific

### DIFF
--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency("html-attributes-utils", "~> 1.0.0", ">= 1.0.0")
   spec.add_dependency("pagy", "~> 6.0")
-  spec.add_dependency "view_component", "~> 2.80.0"
+  spec.add_dependency("view_component", "~> 2")
 
   spec.add_development_dependency "deep_merge"
   spec.add_development_dependency "pry-byebug"


### PR DESCRIPTION
We've seen a problem arise a few times when new versions of `view_component` are released and the automatic upgrades resolve `govuk-components` back to version `1.2.0`.

Now `view_component` has stabilised we can loosen it.