### PR TITLE
Upgrade to GOV.UK Frontend 4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Gem](https://img.shields.io/gem/dt/govuk-components?logo=rubygems)](https://rubygems.org/gems/govuk-components)
 [![Test Coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk-components/test_coverage)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk-components)](https://github.com/DFE-Digital/govuk-components/blob/main/LICENSE)
-[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.3.0-brightgreen)](https://design-system.service.gov.uk)
+[![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.4.0-brightgreen)](https://design-system.service.gov.uk)
 [![Rails](https://img.shields.io/badge/Rails-6.1.5%20%E2%95%B1%207.0.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-2.7.6%20%20%E2%95%B1%203.0.3%20%20%E2%95%B1%203.1.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -23,7 +23,7 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | GOV.UK Design System
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 4.3.0
+        | 4.4.0
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.14.0
     tr.govuk-table__row

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -9,7 +9,7 @@
       "hasInstallScript": true,
       "license": "ISC",
       "dependencies": {
-        "govuk-frontend": "^4.3.0",
+        "govuk-frontend": "^4.4.0",
         "sass": "^1.52.1"
       }
     },
@@ -99,9 +99,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.0.tgz",
-      "integrity": "sha512-U8IyhayW5tpEktTU1Ea2wYyUsmS6UQWkuec/ebB51keSCUfZtrLsj5u9oa6GtwzTatk+3NYMOEEclGNTz4/FKQ==",
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.0.tgz",
+      "integrity": "sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -273,9 +273,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.3.0.tgz",
-      "integrity": "sha512-U8IyhayW5tpEktTU1Ea2wYyUsmS6UQWkuec/ebB51keSCUfZtrLsj5u9oa6GtwzTatk+3NYMOEEclGNTz4/FKQ=="
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.0.tgz",
+      "integrity": "sha512-3Hg4GePCdlynd7F6a3YPOEJx0lDPPP6iBv1S893tv3+efYGWLGvsSFdCG0uob8Xc1O7ckL19dSsFpFhBWUkTNA=="
     },
     "immutable": {
       "version": "4.1.0",

--- a/guide/package.json
+++ b/guide/package.json
@@ -13,7 +13,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "govuk-frontend": "^4.3.0",
+    "govuk-frontend": "^4.4.0",
     "sass": "^1.52.1"
   }
 }


### PR DESCRIPTION
I don't think we need to make any changes to support this release, from [the release notes](https://github.com/alphagov/govuk-frontend/releases/tag/v4.4.0) it appears most of the changes are internal or in components not covered by this gem.
