### PR TITLE
Update pagy version in gemfile

### DIFF
--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |spec|
   spec.files = Dir["{app,config,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
   spec.add_dependency("html-attributes-utils", "~> 0.9", ">= 0.9.2")
-  spec.add_dependency("pagy", "~> 5.10.1")
+  spec.add_dependency("pagy", "~> 6.0")
   spec.add_dependency "view_component", "~> 2.74.1"
 
   spec.add_development_dependency "deep_merge"

--- a/guide/content/components/pagination.slim
+++ b/guide/content/components/pagination.slim
@@ -24,12 +24,12 @@ markdown:
   data: pagination_lots_of_pages_data) do
 
   markdown:
-    Pagy [is very configurable](https://ddnexus.github.io/pagy/api/pagy#variables)
+    Pagy [is very configurable](https://ddnexus.github.io/pagy/docs/api/pagy/#variables)
     and projects might want to tweak the defaults to suit their needs.
 
     To match the guidance in the
     [Design System documentation](https://design-system.service.gov.uk/components/pagination/#for-larger-numbers-of-pages),
-    Pagy's [default size parameter](https://ddnexus.github.io/pagy/how-to.html#control-the-page-links&gsc.tab=0)
+    Pagy's [default size parameter](https://ddnexus.github.io/pagy/docs/how-to/#control-the-page-links&gsc.tab=0)
     should be set to `[1, 1, 1, 1]`.
 
     This means that:


### PR DESCRIPTION
A recent major change (to v6) to the Pagy gem updated their documentation layout and introduced a number of potential breaking changes

This PR updates the gemspec to require at least v6, and re-points the documentation to the new paths

The tests have run and passed locally but I'm happy for you to test more thoroughly