### PR TITLE
Upgrade to Ruby `3.2.0` and bump versions to latest minor release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '2.7.6'
+          ruby-version: '3.0.5'
 
       - name: Install gems
         env:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,8 +9,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.7.6', '3.0.4', '3.1.2']
-        rails: ['6.1.5', '7.0.3']
+        ruby: ['3.0.5', '3.1.3', '3.2.0']
+        rails: ['6.1.7', '7.0.3']
     runs-on: ubuntu-20.04
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:
@@ -42,7 +42,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.0.4
+          ruby-version: 3.0.5
 
       - name: Install gems
         run: |

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Test Coverage](https://api.codeclimate.com/v1/badges/cbcbc140f300b920d833/test_coverage)](https://codeclimate.com/github/DFE-Digital/govuk-components/test_coverage)
 [![GitHub license](https://img.shields.io/github/license/DFE-Digital/govuk-components)](https://github.com/DFE-Digital/govuk-components/blob/main/LICENSE)
 [![GOV.UK Design System Version](https://img.shields.io/badge/GOV.UK%20Design%20System-4.4.1-brightgreen)](https://design-system.service.gov.uk)
-[![Rails](https://img.shields.io/badge/Rails-6.1.5%20%E2%95%B1%207.0.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Ruby-2.7.6%20%20%E2%95%B1%203.0.3%20%20%E2%95%B1%203.1.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Rails](https://img.shields.io/badge/Rails-6.1.7%20%E2%95%B1%207.0.3-E16D6D)](https://weblog.rubyonrails.org/releases/)
+[![Ruby](https://img.shields.io/badge/Ruby-3.0.5%20%20%E2%95%B1%203.1.3%20%20%E2%95%B1%203.2.0-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 This gem provides a suite of reusable components for the [GOV.UK Design System](https://design-system.service.gov.uk/). It is intended to provide a lightweight alternative to the [GOV.UK Publishing Components](https://github.com/alphagov/govuk_publishing_components) library and is built with GitHub’s [ViewComponent](https://github.com/github/view_component) framework.
 

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -32,7 +32,7 @@ table.govuk-table.app-table--constrained
       td.govuk-table__cell.govuk-table__cell--numeric
         | 7.0.3
         br
-        | 6.1.5
+        | 6.1.7
       td.govuk-table__cell.govuk-table__cell--numeric
         | 6.1.4.4
         br
@@ -41,11 +41,11 @@ table.govuk-table.app-table--constrained
       th.govuk-table__header scope="row"
         | Ruby
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 3.1.2
+        | 3.2.0
         br
-        | 3.0.4
+        | 3.1.3
         br
-        | 2.7.6
+        | 3.0.5
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.0.3
         br


### PR DESCRIPTION
Ruby 3.2.0 is scheduled to be released tomorrow.

We aim to support the latest three major versions of Ruby, which will be 3.2.0, 3.1.3 and 3.0.5.

Support for Ruby 2.7 will be dropped. Most projects should have already upgraded to newer versions and the process is quite straightforward so this shouldn't be too problematic for users.

## Final things to do before merging

* [x] Switch -rc1 for the final release version
