### PR TITLE
Add scope support for table headers

### DIFF
--- a/app/components/govuk_component/table_component.html.erb
+++ b/app/components/govuk_component/table_component.html.erb
@@ -1,7 +1,0 @@
-<%= tag.table(**html_attributes) do %>
-  <%= caption %>
-  <%= head %>
-  <% bodies.each do |body| %>
-    <%= body %>
-  <% end %>
-<% end %>

--- a/app/components/govuk_component/table_component.rb
+++ b/app/components/govuk_component/table_component.rb
@@ -20,6 +20,10 @@ module GovukComponent
       build(*(head ? [head, rows] : [rows[0], rows[1..]]), caption_text)
     end
 
+    def call
+      tag.table(**html_attributes) { safe_join([caption, head, bodies]) }
+    end
+
   private
 
     def build(head_data, body_data, caption_text)

--- a/app/components/govuk_component/table_component/body_component.html.erb
+++ b/app/components/govuk_component/table_component/body_component.html.erb
@@ -1,5 +1,0 @@
-<%= tag.tbody(**html_attributes) do %>
-  <% rows.each do |row| %>
-    <%= row %>
-  <% end %>
-<% end %>

--- a/app/components/govuk_component/table_component/body_component.rb
+++ b/app/components/govuk_component/table_component/body_component.rb
@@ -1,5 +1,13 @@
 class GovukComponent::TableComponent::BodyComponent < GovukComponent::Base
-  renders_many :rows, "GovukComponent::TableComponent::RowComponent"
+  renders_many :rows, ->(cell_data: nil, first_cell_is_header: false, classes: [], html_attributes: {}, &block) do
+    GovukComponent::TableComponent::RowComponent.new(
+      cell_data: cell_data,
+      first_cell_is_header: first_cell_is_header,
+      classes: classes,
+      html_attributes: html_attributes,
+      &block
+    )
+  end
 
   def initialize(rows: nil, first_cell_is_header: false, classes: [], html_attributes: {})
     super(classes: classes, html_attributes: html_attributes)

--- a/app/components/govuk_component/table_component/body_component.rb
+++ b/app/components/govuk_component/table_component/body_component.rb
@@ -15,6 +15,10 @@ class GovukComponent::TableComponent::BodyComponent < GovukComponent::Base
     build_rows_from_row_data(rows, first_cell_is_header)
   end
 
+  def call
+    tag.tbody(**html_attributes) { safe_join(rows) }
+  end
+
 private
 
   def build_rows_from_row_data(data, first_cell_is_header)

--- a/app/components/govuk_component/table_component/body_component.rb
+++ b/app/components/govuk_component/table_component/body_component.rb
@@ -1,8 +1,9 @@
 class GovukComponent::TableComponent::BodyComponent < GovukComponent::Base
-  renders_many :rows, ->(cell_data: nil, first_cell_is_header: false, classes: [], html_attributes: {}, &block) do
+  renders_many :rows, ->(cell_data: nil, first_cell_is_header: false, parent: 'tbody', classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::RowComponent.new(
       cell_data: cell_data,
       first_cell_is_header: first_cell_is_header,
+      parent: parent,
       classes: classes,
       html_attributes: html_attributes,
       &block

--- a/app/components/govuk_component/table_component/body_component.rb
+++ b/app/components/govuk_component/table_component/body_component.rb
@@ -1,9 +1,8 @@
 class GovukComponent::TableComponent::BodyComponent < GovukComponent::Base
-  renders_many :rows, ->(cell_data: nil, first_cell_is_header: false, parent: 'tbody', classes: [], html_attributes: {}, &block) do
-    GovukComponent::TableComponent::RowComponent.new(
+  renders_many :rows, ->(cell_data: nil, first_cell_is_header: false, classes: [], html_attributes: {}, &block) do
+    GovukComponent::TableComponent::RowComponent.from_body(
       cell_data: cell_data,
       first_cell_is_header: first_cell_is_header,
-      parent: parent,
       classes: classes,
       html_attributes: html_attributes,
       &block

--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -12,7 +12,7 @@ class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
     "one-quarter"    => "govuk-!-width-one-quarter",
   }.freeze
 
-  def initialize(header: false, scope:, text: nil, numeric: false, width: nil, classes: [], html_attributes: {})
+  def initialize(scope:, header: false, numeric: false, text: nil, width: nil, classes: [], html_attributes: {})
     @header  = header
     @text    = text
     @numeric = numeric

--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
-  attr_reader :text, :header, :numeric, :width
+  attr_reader :text, :header, :numeric, :width, :scope
 
   alias_method :numeric?, :numeric
 
@@ -12,11 +12,12 @@ class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
     "one-quarter"    => "govuk-!-width-one-quarter",
   }.freeze
 
-  def initialize(header: false, text: nil, numeric: false, width: nil, classes: [], html_attributes: {})
+  def initialize(header: false, scope:, text: nil, numeric: false, width: nil, classes: [], html_attributes: {})
     @header  = header
     @text    = text
     @numeric = numeric
     @width   = width
+    @scope   = scope
 
     super(classes: classes, html_attributes: html_attributes)
   end
@@ -36,11 +37,14 @@ private
   end
 
   def cell_element
-    header ? :th : :td
+    header ? 'th' : 'td'
   end
 
   def default_attributes
-    { class: default_classes }
+    {
+      class: default_classes,
+      scope: scope
+    }
   end
 
   def default_classes

--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -1,7 +1,8 @@
 class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
-  attr_reader :text, :header, :numeric, :width, :scope
+  attr_reader :text, :header, :numeric, :width, :scope, :parent
 
   alias_method :numeric?, :numeric
+  alias_method :header?, :header
 
   WIDTHS = {
     "full"           => "govuk-!-width-full",
@@ -12,12 +13,13 @@ class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
     "one-quarter"    => "govuk-!-width-one-quarter",
   }.freeze
 
-  def initialize(scope:, header: false, numeric: false, text: nil, width: nil, classes: [], html_attributes: {})
+  def initialize(scope: nil, header: false, numeric: false, text: nil, width: nil, parent: nil, classes: [], html_attributes: {})
     @header  = header
     @text    = text
     @numeric = numeric
     @width   = width
     @scope   = scope
+    @parent  = parent
 
     super(classes: classes, html_attributes: html_attributes)
   end
@@ -41,17 +43,24 @@ private
   end
 
   def default_attributes
-    {
-      class: default_classes,
-      scope: scope
-    }
+    { class: default_classes, scope: (scope || default_scope) }
+  end
+
+  def default_scope
+    return unless header?
+    return 'col' if parent == 'thead'
+    return 'row' if parent == 'tbody'
+
+    # FIXME: tfoot? https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
+
+    fail(ArgumentError, "invalid parent")
   end
 
   def default_classes
     if header
-      class_names("govuk-table__header", "govuk-table__header--numeric" => numeric?, width_class => width?).split
+      class_names("govuk-table__header", "govuk-table__header--numeric" => numeric?, width_class => width?)
     else
-      class_names("govuk-table__cell", "govuk-table__cell--numeric" => numeric?, width_class => width?).split
+      class_names("govuk-table__cell", "govuk-table__cell--numeric" => numeric?, width_class => width?)
     end
   end
 

--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -47,17 +47,21 @@ private
   end
 
   def determine_scope
-    conditions = { scope: scope, parent: parent, header: header }
+    conditions = { scope: scope, parent: parent, header: header, auto_table_scopes: config.enable_auto_table_scopes }
 
     case conditions
     in { scope: String }
       scope
-    in { scope: false } | { header: false }
+    in { scope: false } | { header: false } | { auto_table_scopes: false }
       nil
-    in { parent: 'thead' }
+    in { auto_table_scopes: true, parent: 'thead' }
       'col'
-    in { parent: 'tbody' }
+    in { auto_table_scopes: true, parent: 'tbody' }
       'row'
+    else
+      Rails.logger.warning("No scope pattern matched")
+
+      nil
     end
   end
 

--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -43,17 +43,22 @@ private
   end
 
   def default_attributes
-    { class: default_classes, scope: (scope || default_scope) }
+    { class: default_classes, scope: determine_scope }
   end
 
-  def default_scope
-    return unless header?
-    return 'col' if parent == 'thead'
-    return 'row' if parent == 'tbody'
+  def determine_scope
+    conditions = { scope: scope, parent: parent, header: header }
 
-    # FIXME: tfoot? https://developer.mozilla.org/en-US/docs/Web/HTML/Element/tfoot
-
-    fail(ArgumentError, "invalid parent")
+    case conditions
+    in { scope: String }
+      scope
+    in { scope: false } | { header: false }
+      nil
+    in { parent: 'thead' }
+      'col'
+    in { parent: 'tbody' }
+      'row'
+    end
   end
 
   def default_classes

--- a/app/components/govuk_component/table_component/head_component.html.erb
+++ b/app/components/govuk_component/table_component/head_component.html.erb
@@ -1,5 +1,0 @@
-<%= tag.thead(**html_attributes) do %>
-  <% rows.each do |row| %>
-    <%= row %>
-  <% end %>
-<% end %>

--- a/app/components/govuk_component/table_component/head_component.rb
+++ b/app/components/govuk_component/table_component/head_component.rb
@@ -1,5 +1,13 @@
 class GovukComponent::TableComponent::HeadComponent < GovukComponent::Base
-  renders_many :rows, "GovukComponent::TableComponent::RowComponent"
+  renders_many :rows, ->(cell_data: nil, header: true, classes: [], html_attributes: {}, &block) do
+    GovukComponent::TableComponent::RowComponent.new(
+      cell_data: cell_data,
+      header: header,
+      classes: classes,
+      html_attributes: html_attributes,
+      &block
+    )
+  end
 
   attr_reader :row_data
 

--- a/app/components/govuk_component/table_component/head_component.rb
+++ b/app/components/govuk_component/table_component/head_component.rb
@@ -1,9 +1,8 @@
 class GovukComponent::TableComponent::HeadComponent < GovukComponent::Base
-  renders_many :rows, ->(cell_data: nil, header: true, parent: 'thead', classes: [], html_attributes: {}, &block) do
-    GovukComponent::TableComponent::RowComponent.new(
+  renders_many :rows, ->(cell_data: nil, header: true, classes: [], html_attributes: {}, &block) do
+    GovukComponent::TableComponent::RowComponent.from_head(
       cell_data: cell_data,
       header: header,
-      parent: parent,
       classes: classes,
       html_attributes: html_attributes,
       &block

--- a/app/components/govuk_component/table_component/head_component.rb
+++ b/app/components/govuk_component/table_component/head_component.rb
@@ -1,8 +1,9 @@
 class GovukComponent::TableComponent::HeadComponent < GovukComponent::Base
-  renders_many :rows, ->(cell_data: nil, header: true, classes: [], html_attributes: {}, &block) do
+  renders_many :rows, ->(cell_data: nil, header: true, parent: 'thead', classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::RowComponent.new(
       cell_data: cell_data,
       header: header,
+      parent: parent,
       classes: classes,
       html_attributes: html_attributes,
       &block

--- a/app/components/govuk_component/table_component/head_component.rb
+++ b/app/components/govuk_component/table_component/head_component.rb
@@ -17,6 +17,10 @@ class GovukComponent::TableComponent::HeadComponent < GovukComponent::Base
     build_rows_from_row_data(rows)
   end
 
+  def call
+    tag.thead(**html_attributes) { safe_join(rows) }
+  end
+
 private
 
   def build_rows_from_row_data(data)

--- a/app/components/govuk_component/table_component/row_component.html.erb
+++ b/app/components/govuk_component/table_component/row_component.html.erb
@@ -1,5 +1,0 @@
-<%= tag.tr(**html_attributes) do %>
-  <% cells.each do |cell| %>
-    <%= cell %>
-  <% end %>
-<% end %>

--- a/app/components/govuk_component/table_component/row_component.rb
+++ b/app/components/govuk_component/table_component/row_component.rb
@@ -1,11 +1,12 @@
 class GovukComponent::TableComponent::RowComponent < GovukComponent::Base
-  renders_many :cells, ->(header: false, scope: nil, text: nil, numeric: false, width: nil, classes: [], html_attributes: {}, &block) do
+  renders_many :cells, ->(scope: nil, header: false, text: nil, numeric: false, width: nil, classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::CellComponent.new(
+      scope: scope,
       header: header,
       text: text,
       numeric: numeric,
       width: width,
-      scope: scope || cell_scope(header, parent),
+      parent: parent,
       classes: classes,
       html_attributes: html_attributes,
       &block
@@ -14,24 +15,25 @@ class GovukComponent::TableComponent::RowComponent < GovukComponent::Base
 
   attr_reader :header, :first_cell_is_header, :parent
 
-  def initialize(parent:, cell_data: nil, first_cell_is_header: false, header: false, classes: [], html_attributes: {})
+  def initialize(cell_data: nil, first_cell_is_header: false, header: false, parent: nil, classes: [], html_attributes: {})
     @header = header
     @first_cell_is_header = first_cell_is_header
-    @parent = parent if parent_valid?(parent)
+    @parent = parent
 
     super(classes: classes, html_attributes: html_attributes)
 
     build_cells_from_cell_data(cell_data)
   end
 
-private
-
-  def parent_valid?(supplied_parent)
-    return true if supplied_parent.nil?
-    return true if supplied_parent.in?(%w(thead tbody))
-
-    fail(ArgumentError, "invalid parent value #{parent}, must be either 'thead' or 'tbody'")
+  def self.from_head(*args, **kwargs, &block)
+    new(*args, parent: 'thead', **kwargs, &block)
   end
+
+  def self.from_body(*args, **kwargs, &block)
+    new(*args, parent: 'tbody', **kwargs, &block)
+  end
+
+private
 
   def build_cells_from_cell_data(cell_data)
     return if cell_data.blank?
@@ -41,14 +43,8 @@ private
 
   def cell_attributes(count)
     cell_is_header?(count).then do |cell_is_header|
-      { header: cell_is_header, scope: cell_scope(cell_is_header, parent) }
+      { header: cell_is_header }
     end
-  end
-
-  def cell_scope(is_header, parent)
-    return unless is_header
-
-    parent == 'thead' ? 'col' : 'row'
   end
 
   def cell_is_header?(count)

--- a/app/components/govuk_component/table_component/row_component.rb
+++ b/app/components/govuk_component/table_component/row_component.rb
@@ -1,5 +1,16 @@
 class GovukComponent::TableComponent::RowComponent < GovukComponent::Base
-  renders_many :cells, "GovukComponent::TableComponent::CellComponent"
+  renders_many :cells, ->(header: false, scope: nil, text: nil, numeric: false, width: nil, classes: [], html_attributes: {}, &block) do
+    GovukComponent::TableComponent::CellComponent.new(
+      header: header,
+      text: text,
+      numeric: numeric,
+      width: width,
+      scope: scope || cell_scope(header, parent),
+      classes: classes,
+      html_attributes: html_attributes,
+      &block
+    )
+  end
 
   attr_reader :header, :first_cell_is_header
 

--- a/app/components/govuk_component/table_component/row_component.rb
+++ b/app/components/govuk_component/table_component/row_component.rb
@@ -33,6 +33,10 @@ class GovukComponent::TableComponent::RowComponent < GovukComponent::Base
     new(*args, parent: 'tbody', **kwargs, &block)
   end
 
+  def call
+    tag.tr(**html_attributes) { safe_join(cells) }
+  end
+
 private
 
   def build_cells_from_cell_data(cell_data)

--- a/guide/content/components/table.slim
+++ b/guide/content/components/table.slim
@@ -47,6 +47,9 @@ p Use the table component to make information easier to compare and scan for
     using the `head` argument. If nothing is set, the first row will be used for
     headers.
 
+    The `first_cell_is_header` parameter can be used to change the first column
+    in the table body to header cells with `scope='row'`.
+
 == render('/partials/example.*',
   caption: "Table with resized columns",
   code: table_with_resized_columns) do

--- a/guide/lib/examples/table_helpers.rb
+++ b/guide/lib/examples/table_helpers.rb
@@ -60,7 +60,7 @@ module Examples
 
     def table_from_arrays
       <<~TABLE
-        = govuk_table(rows: data, caption: "Pokémon species and types")
+        = govuk_table(rows: data, caption: "Pokémon species and types", first_cell_is_header: true)
       TABLE
     end
 
@@ -68,11 +68,11 @@ module Examples
       <<~TABLE_DATA
         {
           data: [
-            ["Name", "Primary type"],
-            ["Weedle", "Bug"],
-            ["Rattata", "Normal"],
-            ["Raichu", "Electric"],
-            ["Golduck", "Water"]
+            ["Name"   , "Primary type", "Catch rate", "Other types"],
+            ["Weedle" , "Bug"         , 255         , "Poison"],
+            ["Rattata", "Normal"      , 255         , "Dark"],
+            ["Raichu" , "Electric"    , 75          , "Psychic"],
+            ["Golduck", "Water"       , 75          , "No other types"]
           ]
         }
       TABLE_DATA

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -64,6 +64,7 @@ module Govuk
     # +:default_warning_text_icon+ "!"
     #
     # +:require_summary_list_action_visually_hidden_text+ when true forces visually hidden text to be set for every action. It can still be explicitly skipped by passing in +nil+. Defaults to +false+
+    # +:enable_auto_table_scopes+ automatically adds a scope of 'col' to th elements in thead and 'row' to th elements in tbody.
     DEFAULTS = {
       default_back_link_text: 'Back',
       default_breadcrumbs_collapse_on_mobile: false,
@@ -99,6 +100,7 @@ module Govuk
       default_link_new_tab_text: "(opens in new tab)",
 
       require_summary_list_action_visually_hidden_text: false,
+      enable_auto_table_scopes: true,
     }.freeze
 
     DEFAULTS.each_key { |k| config_accessor(k) { DEFAULTS[k] } }

--- a/spec/components/govuk_component/configuration/table_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/table_component_configuration_spec.rb
@@ -1,0 +1,37 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::TableComponent::CellComponent, type: :component) do
+  let(:text) { 'Content' }
+  let(:kwargs) { { text: text, header: true, parent: 'tbody' } }
+  let(:component_css_class) { 'govuk-table__cell' }
+
+  describe 'configuration' do
+    describe 'disabling automatic scopes' do
+      context "when enable_auto_table_scopes: true" do
+        subject! { render_inline(GovukComponent::TableComponent::CellComponent.new(**kwargs)) }
+
+        specify "renders a scopeless table cell" do
+          expect(rendered_content).to have_tag("th", text: "Content")
+          expect(html.at_css('th').attributes.keys).to match_array(%w(class scope))
+        end
+      end
+
+      context "when enable_auto_table_scopes: false" do
+        after { Govuk::Components.reset! }
+
+        before do
+          Govuk::Components.configure do |config|
+            config.enable_auto_table_scopes = false
+          end
+        end
+
+        subject! { render_inline(GovukComponent::TableComponent::CellComponent.new(**kwargs)) }
+
+        specify "renders a scopeless table cell" do
+          expect(rendered_content).to have_tag("th", text: "Content")
+          expect(html.at_css('th').attributes.keys).to match_array(%w(class))
+        end
+      end
+    end
+  end
+end

--- a/spec/components/govuk_component/table_component_spec.rb
+++ b/spec/components/govuk_component/table_component_spec.rb
@@ -432,6 +432,43 @@ RSpec.describe(GovukComponent::TableComponent::CellComponent, type: :component) 
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
+
+  describe "controlling scopes" do
+    subject! do
+      render_inline(GovukComponent::TableComponent::RowComponent.new(parent: 'thead')) do |row|
+        row.cell(
+          text: "ABC",
+          scope: false,
+          header: true,
+          html_attributes: { class: "scope_is_false" },
+        )
+        row.cell(
+          text: "DEF",
+          scope: true,
+          header: true,
+          html_attributes: { class: "scope_is_true" },
+        )
+        row.cell(
+          text: "GHI",
+          scope: "custom",
+          header: false,
+          html_attributes: { class: "scope_on_td" },
+        )
+      end
+    end
+
+    it "suppresses the scope attribute when scope: false" do
+      expect(html.at_css('th.scope_is_false').attributes.keys).to match_array(%w(class))
+    end
+
+    it "doesn't suppress the scope attribute when scope: true" do
+      expect(html.at_css('th.scope_is_true').attributes.keys).to match_array(%w(class scope))
+    end
+
+    it "sets the custom scope when scope: 'custom'" do
+      expect(rendered_content).to have_tag('td', with: { class: 'scope_on_td', scope: 'custom' })
+    end
+  end
 end
 
 RSpec.describe(GovukComponent::TableComponent::CaptionComponent, type: :component) do

--- a/spec/components/govuk_component/table_component_spec.rb
+++ b/spec/components/govuk_component/table_component_spec.rb
@@ -22,7 +22,10 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
   end
 
   specify "renders a table with thead and tbody elements" do
-    expect(rendered_content).to have_tag("table", with: { class: "govuk-table" })
+    expect(rendered_content).to have_tag("table", with: { class: "govuk-table" }) do
+      with_tag('thead', with: { class: "govuk-table__head" })
+      with_tag('tbody', with: { class: "govuk-table__body" })
+    end
   end
 
   specify "table has the provided id" do
@@ -417,7 +420,7 @@ end
 
 RSpec.describe(GovukComponent::TableComponent::RowComponent, type: :component) do
   let(:component_css_class) { 'govuk-table__row' }
-  let(:kwargs) { { parent: 'tbody' } }
+  let(:kwargs) { {} }
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'


### PR DESCRIPTION
The [GOV.UK Design System guidance](https://design-system.service.gov.uk/components/table/#table-headers) suggests:

> Use the scope attribute to help users of assistive technology distinguish between row and column headers.

Table header cells `th` can appear in two places:

* Usually they're only present in the `thead` as column headers so they have the attribute `scope='col'`.
* Sometimes they are also used in the first column to mark the row header, then they have the attribute `scope='row'`.

This commit adds a 'scope' parameter to the `CellComponent`. It's a required parameter but it's automatically set in the `#cell_scope` method at the row level if it's missing, so unless you're using the `CellComponent` standalone you should never have to set it.

To determine the kind of scope we also need to know whether the grandparent of the cell is the `thead` or `tbody`, so `parent` has been added as a parameter to the `RowComponent`. Again, it will need to be manually set if the component is used standalone but when used within a table it's automatically assigned.

Any default scope can be totally overridden with any string by passing in `scope: 'xyz'` at the cell level.

### Summary

* `<th>` cells will be assigned a `scope` by default
* when within the `<thead>` it'll be `scope=column`
* when within the `<tbody>` it'll be `scope=row`

### Final steps

* [x] it's probably worth being able to suppress scopes - maybe via `scope: false`
* [x] add a paragraph/example to the guide showcasing this
* [x] is this a big enough change to warrant a major release?

Fixes #377
