### PR TITLE
Infer header status for cells based on their location

### DIFF
--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -59,7 +59,7 @@ private
     in { auto_table_scopes: true, parent: 'tbody' }
       'row'
     else
-      Rails.logger.warning("No scope pattern matched")
+      Rails.logger.warn("No scope pattern matched")
 
       nil
     end

--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -13,13 +13,13 @@ class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
     "one-quarter"    => "govuk-!-width-one-quarter",
   }.freeze
 
-  def initialize(scope: nil, header: false, numeric: false, text: nil, width: nil, parent: nil, classes: [], html_attributes: {})
-    @header  = header
+  def initialize(scope: nil, header: nil, numeric: false, text: nil, width: nil, parent: nil, classes: [], html_attributes: {})
     @text    = text
     @numeric = numeric
     @width   = width
     @scope   = scope
     @parent  = parent
+    @header  = (header.nil?) ? in_thead? : header
 
     super(classes: classes, html_attributes: html_attributes)
   end
@@ -75,5 +75,9 @@ private
 
   def width_class
     WIDTHS.fetch(width, nil)
+  end
+
+  def in_thead?
+    parent == "thead"
   end
 end

--- a/app/components/govuk_component/table_component/head_component.rb
+++ b/app/components/govuk_component/table_component/head_component.rb
@@ -1,8 +1,7 @@
 class GovukComponent::TableComponent::HeadComponent < GovukComponent::Base
-  renders_many :rows, ->(cell_data: nil, header: true, classes: [], html_attributes: {}, &block) do
+  renders_many :rows, ->(cell_data: nil, classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::RowComponent.from_head(
       cell_data: cell_data,
-      header: header,
       classes: classes,
       html_attributes: html_attributes,
       &block
@@ -26,7 +25,7 @@ private
   def build_rows_from_row_data(data)
     return if data.blank?
 
-    data.each { |d| row(cell_data: d, header: true) }
+    data.each { |d| row(cell_data: d) }
   end
 
   def default_attributes

--- a/app/components/govuk_component/table_component/row_component.rb
+++ b/app/components/govuk_component/table_component/row_component.rb
@@ -1,5 +1,5 @@
 class GovukComponent::TableComponent::RowComponent < GovukComponent::Base
-  renders_many :cells, ->(scope: nil, header: false, text: nil, numeric: false, width: nil, classes: [], html_attributes: {}, &block) do
+  renders_many :cells, ->(scope: nil, header: nil, text: nil, numeric: false, width: nil, classes: [], html_attributes: {}, &block) do
     GovukComponent::TableComponent::CellComponent.new(
       scope: scope,
       header: header,
@@ -13,10 +13,9 @@ class GovukComponent::TableComponent::RowComponent < GovukComponent::Base
     )
   end
 
-  attr_reader :header, :first_cell_is_header, :parent
+  attr_reader :first_cell_is_header, :parent
 
-  def initialize(cell_data: nil, first_cell_is_header: false, header: false, parent: nil, classes: [], html_attributes: {})
-    @header = header
+  def initialize(cell_data: nil, first_cell_is_header: false, parent: nil, classes: [], html_attributes: {})
     @first_cell_is_header = first_cell_is_header
     @parent = parent
 
@@ -52,10 +51,14 @@ private
   end
 
   def cell_is_header?(count)
-    header || (first_cell_is_header && count.zero?)
+    in_thead? || (first_cell_is_header && count.zero?)
   end
 
   def default_attributes
     { class: %w(govuk-table__row) }
+  end
+
+  def in_thead?
+    parent == "thead"
   end
 end

--- a/guide/lib/examples/table_helpers.rb
+++ b/guide/lib/examples/table_helpers.rb
@@ -7,9 +7,9 @@ module Examples
 
           - table.head do |head|
             - head.row do |row|
-              - row.cell(header: true, text: 'Name')
-              - row.cell(header: true, text: 'Types')
-              - row.cell(header: true, text: 'Pokédex number', numeric: true)
+              - row.cell(text: 'Name')
+              - row.cell(text: 'Types')
+              - row.cell(text: 'Pokédex number', numeric: true)
 
           - table.body do |body|
             - body.row do |row|
@@ -36,8 +36,8 @@ module Examples
 
           - table.head do |head|
             - head.row do |row|
-              - row.cell(header: true, text: 'Generation')
-              - row.cell(header: true, text: 'Years')
+              - row.cell(text: 'Generation')
+              - row.cell(text: 'Years')
 
           - table.body do |body|
             - body.row do |row|
@@ -85,8 +85,8 @@ module Examples
 
           - table.head do |head|
             - head.row do |row|
-              - row.cell(header: true, text: 'Name', width: 'one-third')
-              - row.cell(header: true, text: 'Description')
+              - row.cell(text: 'Name', width: 'one-third')
+              - row.cell(text: 'Description')
 
           - table.body do |body|
             - body.row do |row|

--- a/spec/components/govuk_component/table_component_spec.rb
+++ b/spec/components/govuk_component/table_component_spec.rb
@@ -12,11 +12,17 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
       table.caption(text: "What a nice table")
 
       table.head do |head|
-        head.row {}
+        head.row do |row|
+          row.cell(text: "A")
+          row.cell(text: "B")
+        end
       end
 
       table.body do |body|
-        body.row {}
+        body.row do |row|
+          row.cell(text: "C")
+          row.cell(text: "D")
+        end
       end
     end
   end
@@ -36,8 +42,16 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
     expect(rendered_content).to have_tag("table > thead")
   end
 
+  specify "the cells in thead should default to th" do
+    expect(rendered_content).to have_tag("table > thead > tr > th", count: 2)
+  end
+
   specify "renders a tbody element" do
     expect(rendered_content).to have_tag("table > tbody")
+  end
+
+  specify "the cells in tbody should default to td" do
+    expect(rendered_content).to have_tag("table > tbody > tr > td", count: 2)
   end
 
   context "when there is more than one tbody" do


### PR DESCRIPTION
This change allows us to remove the header param from several places as (due to the changes made in #382) we can tidily infer whether a cell should be a `th` or a `td` by whether its parent is a `thead` or a `tbody` while still respecting the `first_cell_is_header` setting and any manual overrides.

The default is applied at the cell level whenever `header: nil`, when it's truthy or falsy the override will take precedence.

## Changes

- Fix call to Logger#warning with Logger#warn
- Set table header default default by location
