### PR TITLE
Remove new tab functionality

### DIFF
--- a/guide/content/helpers/link.slim
+++ b/guide/content/helpers/link.slim
@@ -17,23 +17,6 @@ markdown:
     [0]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a
 
 == render('/partials/example.*',
-  caption: "Links that open in a new tab",
-  code: govuk_link_to_new_tab) do
-
-  markdown:
-    You can use the `new_tab` parameter to automatically set the `target` and
-    `rel` [attributes as suggested by the design system][0].
-
-    When the link text is passed in as a string argument, 'opens in new tab' is
-    added to the end automatically. No suffix is added when the helper is used
-    in block mode.
-
-    The default text can be set using the `default_link_new_tab_text` configuration option
-    and it can be suppressed by setting it to an empty string.
-
-    [0]: https://design-system.service.gov.uk/styles/typography/#opening-links-in-a-new-tab
-
-== render('/partials/example.*',
   caption: "Inverse hyperlink",
   code: govuk_link_to_inverse,
   inverse: true) do

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -111,45 +111,6 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       it { is_expected.to have_tag('a', with: { href: link_url, class: %w(green govuk-link--no-underline) }, text: link_text) }
     end
-
-    describe "opening links in new tabs" do
-      context "when new_tab: true" do
-        let(:default_new_tab_text) { "(opens in new tab)" }
-        subject { govuk_link_to(link_text, link_params, new_tab: true) }
-
-        it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: "#{link_text} #{default_new_tab_text}") }
-      end
-
-      context "when new_tab: '(opens in new window)'" do
-        let(:overridden_new_tab_text) { "(opens in new window)" }
-        subject { govuk_link_to(link_text, link_params, new_tab: overridden_new_tab_text) }
-
-        it { is_expected.to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: "#{link_text} #{overridden_new_tab_text}") }
-      end
-
-      context "when new_tab is an empty string" do
-        let(:overridden_new_tab_text) { "" }
-        subject { govuk_link_to(link_text, link_params, new_tab: overridden_new_tab_text) }
-
-        it "appends nothing to the string" do
-          expect(subject).to have_tag('a', with: { href: link_url, class: %w(govuk-link), target: "_blank", rel: "noreferrer noopener" }, text: link_text)
-        end
-      end
-
-      context "when custom 'rel' and 'target' values are provided" do
-        let(:custom_rel) { { rel: "help" } }
-        let(:custom_target) { { target: "new" } }
-        subject { govuk_link_to(link_text, link_params, { **custom_rel, **custom_target }, new_tab: true) }
-
-        it "replaces the default target value with the provided one" do
-          expect(subject).to have_tag('a', with: { rel: "noreferrer noopener help" })
-        end
-
-        it "appends the provided rel value to 'noreferrer' and 'noopener'" do
-          expect(subject).to have_tag('a', with: { target: 'new' })
-        end
-      end
-    end
   end
 
   describe "#govuk_mail_to" do
@@ -311,47 +272,6 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
 
       specify "renders a form with an button that has the custom classes" do
         expect(subject).to have_tag("a", with: { href: button_link_url, class: %w(govuk-button yellow) }, text: button_link_text)
-      end
-    end
-
-    describe "opening links in new tabs" do
-      let(:link_params) { { controller: :some_controller, action: :some_action } }
-
-      context "when new_tab: true" do
-        let(:default_new_tab_text) { "(opens in new tab)" }
-        subject { govuk_button_link_to(button_link_text, link_params, new_tab: true) }
-
-        it { is_expected.to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: "#{button_link_text} #{default_new_tab_text}") }
-      end
-
-      context "when new_tab: '(opens in new window)'" do
-        let(:overridden_new_tab_text) { "(opens in new window)" }
-        subject { govuk_button_link_to(button_link_text, link_params, new_tab: overridden_new_tab_text) }
-
-        it { is_expected.to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: "#{button_link_text} #{overridden_new_tab_text}") }
-      end
-
-      context "when new_tab is an empty string" do
-        let(:overridden_new_tab_text) { "" }
-        subject { govuk_button_link_to(button_link_text, link_params, new_tab: overridden_new_tab_text) }
-
-        it "appends nothing to the string" do
-          expect(subject).to have_tag('a', with: { href: button_link_url, class: %w(govuk-button), target: "_blank", rel: "noreferrer noopener" }, text: button_link_text)
-        end
-      end
-
-      context "when custom 'rel' and 'target' values are provided" do
-        let(:custom_rel) { { rel: "help" } }
-        let(:custom_target) { { target: "new" } }
-        subject { govuk_button_link_to(button_link_text, link_params, { **custom_rel, **custom_target }, new_tab: true) }
-
-        it "replaces the default target value with the provided one" do
-          expect(subject).to have_tag('a', with: { rel: "noreferrer noopener help" })
-        end
-
-        it "appends the provided rel value to 'noreferrer' and 'noopener'" do
-          expect(subject).to have_tag('a', with: { target: 'new' })
-        end
       end
     end
   end


### PR DESCRIPTION
Despite this being a good move the implementation breaks because of the close ties to Rails' parameter names. We have to do a lot of juggling of params to make them flexible enough to accept either a name and href, a href and block, a name and Rails action/controller via options etc.

Adding a named param `new_tab` results in the unenclosed options/extra_options hash being interpreted as a named param, meaning users of this library would need to go through their app and make changes like this:

### Before:

```slim
= link_to("some page", "/some/path", class: "thing")
```

### After:

```slim
= link_to("some page", "/some/path", { class: "thing" })
```

Otherwise, class is treated as a named arg rather than being the options hash.

The only nice solution here is to create an alternative, clean set of link helpers that take GOV.UK-style named parameter arguments.
