### PR TITLE
Add configuration option for visually hidden space on SummaryListComponent::ActionComponent

### DIFF
--- a/app/components/govuk_component/summary_list_component/action_component.rb
+++ b/app/components/govuk_component/summary_list_component/action_component.rb
@@ -19,8 +19,10 @@ class GovukComponent::SummaryListComponent::ActionComponent < GovukComponent::Ba
   end
 
   def call
+    space = config.summary_list_action_visually_hidden_space ? nil : " "
+
     link_to(href, **html_attributes) do
-      safe_join([action_text, visually_hidden_span].compact, " ")
+      safe_join([action_text, visually_hidden_span].compact, space)
     end
   end
 
@@ -37,6 +39,8 @@ private
   end
 
   def visually_hidden_span
-    tag.span(visually_hidden_text, class: "govuk-visually-hidden") if visually_hidden_text.present?
+    space = config.summary_list_action_visually_hidden_space ? "&nbsp;" : nil
+
+    tag.span("#{space}#{visually_hidden_text}", class: "govuk-visually-hidden") if visually_hidden_text.present?
   end
 end

--- a/lib/govuk/components/engine.rb
+++ b/lib/govuk/components/engine.rb
@@ -100,6 +100,7 @@ module Govuk
       default_link_new_tab_text: "(opens in new tab)",
 
       require_summary_list_action_visually_hidden_text: false,
+      summary_list_action_visually_hidden_space: false,
       enable_auto_table_scopes: true,
     }.freeze
 

--- a/spec/components/govuk_component/configuration/summary_list_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/summary_list_configuration_spec.rb
@@ -58,5 +58,29 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
         end
       end
     end
+
+    describe "summary_list_action_visually_hidden_space" do
+      before do
+        Govuk::Components.configure do |config|
+          config.summary_list_action_visually_hidden_space = true
+        end
+      end
+
+      let(:visually_hidden_text) { "visually hidden info" }
+
+      subject! do
+        render_inline(GovukComponent::SummaryListComponent.new) do |sl|
+          sl.with_row do |row|
+            row.with_key(text: "key one")
+            row.with_value(text: "value one")
+            row.with_action(text: "action one", href: "/action-one", visually_hidden_text: visually_hidden_text)
+          end
+        end
+      end
+
+      specify "renders a span with a space inside the visually hidden text" do
+        expect(rendered_content).to have_tag("span", text: "&nbsp;#{visually_hidden_text}", with: { class: "govuk-visually-hidden" })
+      end
+    end
   end
 end


### PR DESCRIPTION
As per issue #402. We are adding a configuration option to allow moving the space in the summary list actions from the visually shown to visually hidden text.

I'm not sure whether we should be using nbsp or a regular space here but I've put in nbsp for now as that was the recommendation