### PR TITLE
Fix show_actions_column overwrite

### DIFF
--- a/app/components/govuk_component/summary_list_component.rb
+++ b/app/components/govuk_component/summary_list_component.rb
@@ -47,7 +47,7 @@ module GovukComponent
     end
 
     def build(rows)
-      @show_actions_column = rows.any? { |r| r.key?(:actions) }
+      @show_actions_column &&= rows.any? { |r| r.key?(:actions) }
 
       rows.each do |data|
         k, v, a = data.values_at(:key, :value, :actions)

--- a/spec/components/govuk_component/summary_list_component_spec.rb
+++ b/spec/components/govuk_component/summary_list_component_spec.rb
@@ -243,7 +243,8 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
   end
 
   describe "passing data directly into the summary list component" do
-    subject! { render_inline(described_class.new(rows: rows)) }
+    subject! { render_inline(described_class.new(rows: rows, actions: actions)) }
+    let(:actions) { true }
 
     describe "setting keys, values and actions" do
       let(:rows) do
@@ -388,6 +389,18 @@ RSpec.describe(GovukComponent::SummaryListComponent, type: :component) do
                 },
                 text: /\ADelete/
               }) { with_tag("span", with: { class: "govuk-visually-hidden" }, text: " address") }
+            end
+          end
+        end
+      end
+
+      context "when actions are set to false" do
+        let(:actions) { false }
+
+        specify "doesn't render an action column" do
+          expect(rendered_content).to have_tag("dl", with: { class: component_css_class }) do
+            with_tag("div", with: { class: %(govuk-summary-list__row) }) do
+              without_tag("dd", with: { class: "govuk-summary-list__actions" })
             end
           end
         end


### PR DESCRIPTION
If the `show_actions_column` option is set to `false`, it should not be overwritten when the rows have actions. This was an issue when generating rows dynamically and wanting to hide the actions column in certain cases.