### PR TITLE
Remove the disabled button param

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -12,7 +12,6 @@ module GovukLinkHelper
   }.freeze
 
   BUTTON_STYLES = {
-    disabled:  "govuk-button--disabled",
     secondary: "govuk-button--secondary",
     warning:   "govuk-button--warning",
   }.freeze

--- a/guide/content/helpers/button.slim
+++ b/guide/content/helpers/button.slim
@@ -28,11 +28,6 @@ p.govuk-body
   code: govuk_button_other_styles) do
 
   markdown:
-    ### Disabled buttons
-
-    Disabled buttons are created using `disabled: true`. They have poor
-    contrast and can confuse some users, so avoid them if possible.
-
     ### Secondary buttons
 
     Secondary buttons are created with `secondary: true`. Pages usually have

--- a/guide/lib/examples/link_helpers.rb
+++ b/guide/lib/examples/link_helpers.rb
@@ -47,7 +47,6 @@ module Examples
     def govuk_button_other_styles
       <<~BUTTONS
         .govuk-button-group
-          = govuk_button_link_to('A disabled button', '#', { disabled: true })
           = govuk_button_link_to('A secondary button', '#', { secondary: true })
           = govuk_button_link_to('A warning button', '#', { warning: true })
       BUTTONS

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -51,7 +51,6 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     {
       secondary: 'govuk-button--secondary',
       warning:   'govuk-button--warning',
-      disabled:  'govuk-button--disabled',
     }.each do |style, css_class|
       describe "generating a #{style}-style button with '#{style}: true'" do
         let(:args) { [style] }
@@ -200,11 +199,11 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
     end
 
     context "adding custom classes" do
-      subject { govuk_button_to(button_text, button_params, { class: "yellow", disabled: true }) }
+      subject { govuk_button_to(button_text, button_params, { class: "yellow", secondary: true }) }
 
       specify "renders a form with an button that has the custom classes" do
         expect(subject).to have_tag("form", with: { class: "button_to", action: button_url }) do
-          with_tag("input", with: { type: "submit", class: %w(govuk-button yellow govuk-button--disabled) })
+          with_tag("input", with: { type: "submit", class: %w(govuk-button yellow govuk-button--secondary) })
         end
       end
     end


### PR DESCRIPTION
The `govuk-button--disabled` class [is going to be removed from the design system](https://github.com/alphagov/govuk-frontend/pull/3187) and its use is discouraged. Links styled as buttons should not be disabled and buttons should be disabled using the `disabled` HTML attribute instead.
