### PR TITLE
Inverse buttons

### DIFF
--- a/app/helpers/govuk_link_helper.rb
+++ b/app/helpers/govuk_link_helper.rb
@@ -15,6 +15,7 @@ module GovukLinkHelper
     disabled:  "govuk-button--disabled",
     secondary: "govuk-button--secondary",
     warning:   "govuk-button--warning",
+    inverse:   "govuk-button--inverse",
   }.freeze
 
   def govuk_link_classes(*styles, default_class: 'govuk-link')

--- a/guide/content/helpers/button.slim
+++ b/guide/content/helpers/button.slim
@@ -24,6 +24,15 @@ p.govuk-body
       button instead.
 
 == render('/partials/example.*',
+  caption: "Inverse buttons",
+  code: govuk_button_inverse,
+  inverse: true) do
+
+  markdown:
+    Inverse buttons can be used to make buttons stand out on coloured backgrounds. They
+    are frequently used on landing pages.
+
+== render('/partials/example.*',
   caption: "Other button styles",
   code: govuk_button_other_styles) do
 

--- a/guide/content/stylesheets/application.scss
+++ b/guide/content/stylesheets/application.scss
@@ -68,3 +68,39 @@ $x-govuk-brand-colour: #28a;
     }
   }
 }
+
+// inverse buttons, this can be removed once the functionality is supported by
+// the design system. https://github.com/alphagov/govuk-frontend/pull/3556
+$govuk-inverse-button-colour: govuk-colour("white");
+$govuk-inverse-button-text-colour: govuk-colour("blue");
+$govuk-inverse-button-hover-colour: govuk-tint($govuk-inverse-button-text-colour, 90%);
+$govuk-inverse-button-shadow-colour: govuk-shade($govuk-inverse-button-text-colour, 30%);
+
+.blue-bg { background: govuk-colour("blue"); }
+
+.govuk-button--inverse {
+  background-color: $govuk-inverse-button-colour;
+  box-shadow: 0 2px 0 $govuk-inverse-button-shadow-colour;
+
+  &,
+  &:link,
+  &:visited,
+  &:active,
+  &:hover {
+    color: $govuk-inverse-button-text-colour;
+  }
+
+  @include _govuk-compatibility(govuk_template) {
+    &:link:focus {
+      color: $govuk-inverse-button-text-colour;
+    }
+  }
+
+  &:hover {
+    background-color: $govuk-inverse-button-hover-colour;
+
+    &[disabled] {
+      background-color: $govuk-inverse-button-colour;
+    }
+  }
+}

--- a/guide/content/stylesheets/components/_example.scss
+++ b/guide/content/stylesheets/components/_example.scss
@@ -17,7 +17,7 @@
 
     // make dark so the inverted hyperlinks (where the text is white) are visible
     &.inverse {
-      background: govuk-colour('black');
+      background: govuk-colour('blue');
     }
   }
 

--- a/guide/lib/examples/link_helpers.rb
+++ b/guide/lib/examples/link_helpers.rb
@@ -44,6 +44,12 @@ module Examples
       %(= govuk_button_link_to 'A link styled like a button', '#')
     end
 
+    def govuk_button_inverse
+      <<~BUTTON
+        = govuk_button_link_to('An inverse button', '#', { inverse: true })
+      BUTTON
+    end
+
     def govuk_button_other_styles
       <<~BUTTONS
         .govuk-button-group

--- a/spec/helpers/govuk_link_helper_spec.rb
+++ b/spec/helpers/govuk_link_helper_spec.rb
@@ -52,6 +52,7 @@ RSpec.describe(GovukLinkHelper, type: 'helper') do
       secondary: 'govuk-button--secondary',
       warning:   'govuk-button--warning',
       disabled:  'govuk-button--disabled',
+      inverse:   'govuk-button--inverse',
     }.each do |style, css_class|
       describe "generating a #{style}-style button with '#{style}: true'" do
         let(:args) { [style] }


### PR DESCRIPTION
Inverse buttons [were recently added to GOV.UK frontend](https://github.com/alphagov/govuk-frontend/pull/3556) but have not yet made it into the Design System proper. This change add support for them as a keyword argument `inverse` to button, meaning it can be used in place of `disabled`, `secondary` and `warning`.

- Add support for inverse buttons
- Add a inverse button example to the guide
