### PR TITLE
Use correct class names in cell widths

### DIFF
--- a/app/components/govuk_component/table_component/cell_component.rb
+++ b/app/components/govuk_component/table_component/cell_component.rb
@@ -4,17 +4,6 @@ class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
   alias_method :numeric?, :numeric
   alias_method :header?, :header
 
-  def self.widths
-    {
-      "full"           => "#{brand}-!-width-full",
-      "three-quarters" => "#{brand}-!-width-three-quarters",
-      "two-thirds"     => "#{brand}-!-width-two-thirds",
-      "one-half"       => "#{brand}-!-width-one-half",
-      "one-third"      => "#{brand}-!-width-one-third",
-      "one-quarter"    => "#{brand}-!-width-one-quarter",
-    }.freeze
-  end
-
   def initialize(scope: nil, header: nil, numeric: false, text: nil, width: nil, parent: nil, rowspan: nil, colspan: nil, classes: [], html_attributes: {})
     @text    = text
     @numeric = numeric
@@ -24,6 +13,7 @@ class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
     @colspan = colspan
     @rowspan = rowspan
     @header  = (header.nil?) ? in_thead? : header
+    @width   = widths.fetch(width, nil)
 
     super(classes:, html_attributes:)
   end
@@ -33,6 +23,17 @@ class GovukComponent::TableComponent::CellComponent < GovukComponent::Base
   end
 
 private
+
+  def widths
+    @widths ||= {
+      "full"           => "#{brand}-!-width-full",
+      "three-quarters" => "#{brand}-!-width-three-quarters",
+      "two-thirds"     => "#{brand}-!-width-two-thirds",
+      "one-half"       => "#{brand}-!-width-one-half",
+      "one-third"      => "#{brand}-!-width-one-third",
+      "one-quarter"    => "#{brand}-!-width-one-quarter",
+    }
+  end
 
   def width?
     width.present?

--- a/spec/components/govuk_component/table_component_spec.rb
+++ b/spec/components/govuk_component/table_component_spec.rb
@@ -475,12 +475,23 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
     end
   end
 
-  describe "custom colum widths" do
+  describe "custom column widths" do
+    let(:widths) do
+      {
+        "full"           => "govuk-!-width-full",
+        "three-quarters" => "govuk-!-width-three-quarters",
+        "two-thirds"     => "govuk-!-width-two-thirds",
+        "one-half"       => "govuk-!-width-one-half",
+        "one-third"      => "govuk-!-width-one-third",
+        "one-quarter"    => "govuk-!-width-one-quarter",
+      }
+    end
+
     subject! do
       render_inline(GovukComponent::TableComponent.new) do |table|
         table.with_head do |head|
           head.with_row do |row|
-            GovukComponent::TableComponent::CellComponent.widths.each_key do |width|
+            widths.each_key do |width|
               row.with_cell(text: width, header: true, width:)
             end
           end
@@ -489,8 +500,9 @@ RSpec.describe(GovukComponent::TableComponent, type: :component) do
     end
 
     specify "adds the width class correctly" do
-      GovukComponent::TableComponent::CellComponent.widths.each_key do |width, expected_class|
-        expect(rendered_content).to have_tag("table > thead > tr > th", with: { class: expected_class }, text: width)
+      widths.each do |width, expected_class|
+        escaped_expected_class = expected_class.gsub("!", "\\!") # Escape the exclamation mark for CSS selectors.
+        expect(rendered_content).to have_tag("table > thead > tr > th", with: { class: escaped_expected_class }, text: width)
       end
     end
   end


### PR DESCRIPTION
We are using the short/convenience width name as the class for cell widths, so:

```
row.with_cell(text: 'Name', width: 'one-third')
```

Will render out as:

```
<th class="govuk-table__header one-third" scope="col">Name</th>
```

As a result the width is not correctly applied; we need to use the fully qualified class name from GOV UK frotend.

Update `CellComponent` to convert to the correct class name, for example `govuk-!-width-one-third`.

Fix an issue with the specs where Nokogiri throws an error due to trying to run a CSS selectcor with an `!` in it; this needs to be escaped.

As a workaround you can pass in the fully qualified class name to the `width`, so `width: "govuk-!-width-one-third"`.