### PR TITLE
Rename the pagination `ellipses` class to `ellipsis`

### DIFF
--- a/app/components/govuk_component/pagination_component/item.rb
+++ b/app/components/govuk_component/pagination_component/item.rb
@@ -61,7 +61,7 @@ private
   end
 
   def ellipsis_item
-    tag.li("⋯", class: ["#{brand}-pagination__item", "#{brand}-pagination__item--ellipses"])
+    tag.li("⋯", class: ["#{brand}-pagination__item", "#{brand}-pagination__item--ellipsis"])
   end
 
   def default_attributes

--- a/spec/components/govuk_component/pagination_component_spec.rb
+++ b/spec/components/govuk_component/pagination_component_spec.rb
@@ -263,8 +263,8 @@ RSpec.describe(GovukComponent::PaginationComponent, type: :component) do
   context "when there are more pages than can be shown" do
     let(:count) { 90 }
 
-    specify "renders ellipses" do
-      expect(rendered_content).to have_tag("li", with: { class: %w(govuk-pagination__item govuk-pagination__item--ellipses) })
+    specify "renders an ellipsis" do
+      expect(rendered_content).to have_tag("li", with: { class: %w(govuk-pagination__item govuk-pagination__item--ellipsis) })
     end
   end
 


### PR DESCRIPTION
See alphagov/govuk-frontend#5882
