### PR TITLE
Various version bumps

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,8 +10,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['3.2.5', '3.3.6']
-        rails: ['7.1.5', '7.2.2', '8.0.0', '8.1.0']
+        ruby: ['3.3.11', '4.0.2']
+        rails: ['7.2.2', '8.0.0', '8.1.0']
     runs-on: ubuntu-latest
     name: Testing with Ruby ${{ matrix.ruby }} and Rails ${{ matrix.rails }}
     steps:

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![Gem](https://img.shields.io/gem/dt/govuk-components?logo=rubygems)](https://rubygems.org/gems/govuk-components)
 [![Licence](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE.txt)
 [![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-6.0.0-brightgreen)](https://design-system.service.gov.uk)
-[![ViewComponent](https://img.shields.io/badge/ViewComponent-3.24.0-brightgreen)](https://viewcomponent.org/)
+[![ViewComponent](https://img.shields.io/badge/ViewComponent-4.6.0-brightgreen)](https://viewcomponent.org/)
 [![Rails](https://img.shields.io/badge/Rails-7.2.2%20%E2%95%B1%208.0.2%20%E2%95%B1%208.1.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
 [![Ruby](https://img.shields.io/badge/Ruby-3.3.11%20%20%E2%95%B1%204.0.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 

--- a/README.md
+++ b/README.md
@@ -6,8 +6,8 @@
 [![Licence](https://img.shields.io/github/license/x-govuk/govuk-components)](https://github.com/x-govuk/govuk-components/blob/main/LICENSE.txt)
 [![GOV.UK Design System version](https://img.shields.io/badge/GOV.UK%20Design%20System-6.0.0-brightgreen)](https://design-system.service.gov.uk)
 [![ViewComponent](https://img.shields.io/badge/ViewComponent-3.24.0-brightgreen)](https://viewcomponent.org/)
-[![Rails](https://img.shields.io/badge/Rails-7.1.5%20%E2%95%B1%207.2.2%20%E2%95%B1%208.0.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
-[![Ruby](https://img.shields.io/badge/Ruby-3.2.5%20%20%E2%95%B1%203.2.6%20%20%E2%95%B1%203.3.6-E16D6D)](https://www.ruby-lang.org/en/downloads/)
+[![Rails](https://img.shields.io/badge/Rails-7.2.2%20%E2%95%B1%208.0.2%20%E2%95%B1%208.1.0-E16D6D)](https://weblog.rubyonrails.org/releases/)
+[![Ruby](https://img.shields.io/badge/Ruby-3.3.11%20%20%E2%95%B1%204.0.2-E16D6D)](https://www.ruby-lang.org/en/downloads/)
 
 This gem provides a suite of reusable components for the [GOV.UK Design System](https://design-system.service.gov.uk/). It is intended to provide a lightweight alternative to the [GOV.UK Publishing Components](https://github.com/alphagov/govuk_publishing_components) library and is built with GitHub’s [ViewComponent](https://github.com/github/view_component) framework.
 

--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "html-attributes-utils", "~> 1.0.0", ">= 1.0.0"
   spec.add_dependency "pagy", ">= 6", "< 10"
-  spec.add_dependency "view_component", ">= 4.0", "< 4.3"
+  spec.add_dependency "view_component", ">= 4.0", "< 4.7"
 
   spec.add_development_dependency "deep_merge"
   spec.add_development_dependency "ostruct"

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -16,16 +16,14 @@ table.govuk-table
         | GOV.UK Components
       th class="govuk-table__header govuk-!-width-one-third govuk-table__header--numeric" scope="col"
         | #{Govuk::Components::VERSION}
-      th class="govuk-table__header govuk-!-width-one-third govuk-table__header--numeric" scope="col"
-        | 2.1.5
   tbody.govuk-table__body
     tr.govuk-table__row
       th.govuk-table__header scope="row"
         | GOV.UK Design System
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 6.0.0.rc0
       td.govuk-table__cell.govuk-table__cell--numeric
         | 3.14.0
+        | 6.1.0
     tr.govuk-table__row
       th.govuk-table__header scope="row"
         | Ruby on Rails

--- a/guide/content/introduction/supported-versions.slim
+++ b/guide/content/introduction/supported-versions.slim
@@ -21,32 +21,20 @@ table.govuk-table
       th.govuk-table__header scope="row"
         | GOV.UK Design System
       td.govuk-table__cell.govuk-table__cell--numeric
-      td.govuk-table__cell.govuk-table__cell--numeric
-        | 3.14.0
         | 6.1.0
     tr.govuk-table__row
       th.govuk-table__header scope="row"
         | Ruby on Rails
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 7.1.5
-        br
         | 7.2.2
         br
         | 8.0.0
-      td.govuk-table__cell.govuk-table__cell--numeric
-        | 6.1.4.4
         br
-        | 6.0.4.4
+        | 8.1.0
     tr.govuk-table__row
       th.govuk-table__header scope="row"
         | Ruby
       td.govuk-table__cell.govuk-table__cell--numeric
-        | 3.3.6
+        | 3.3.11
         br
-        | 3.2.5
-      td.govuk-table__cell.govuk-table__cell--numeric
-        | 3.0.3
-        br
-        | 2.7.5
-        br
-        | 2.6.9
+        | 4.0.2

--- a/guide/package-lock.json
+++ b/guide/package-lock.json
@@ -11,7 +11,7 @@
       "license": "ISC",
       "dependencies": {
         "@x-govuk/govuk-prototype-components": "git://github.com/x-govuk/govuk-prototype-components#govuk-frontend-v6",
-        "govuk-frontend": "6.0.0-rc.0",
+        "govuk-frontend": "6.1.0",
         "sass": "^1.77.8"
       }
     },
@@ -401,9 +401,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "6.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.0.0-rc.0.tgz",
-      "integrity": "sha512-OqJ+pH9eROattTmHf5FKM7P8c7N4Xa34gR8nudOOQNYcP8btEM1fYgIfcCip6ang50nPUC6YuxL/iyOkAKOwyA==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-6.1.0.tgz",
+      "integrity": "sha512-sqivexZFa82LiDIDVMItsUlqEXE/wEUWWBqzEoxHvUFLBH7bY0C8lVrj1qsDThSnj5JEUMS7isBAbKnfQ5Qp6g==",
       "license": "MIT",
       "engines": {
         "node": ">= 4.2.0"

--- a/guide/package.json
+++ b/guide/package.json
@@ -14,7 +14,7 @@
   "license": "ISC",
   "dependencies": {
     "@x-govuk/govuk-prototype-components": "git://github.com/x-govuk/govuk-prototype-components#govuk-frontend-v6",
-    "govuk-frontend": "6.0.0-rc.0",
+    "govuk-frontend": "6.1.0",
     "sass": "^1.77.8"
   }
 }


### PR DESCRIPTION
- **Upgrade to govuk-frontend 6.1.0**
- **Bump supported Ruby and Rails versions to latest**
- **Bump supported ViewComponent to 4.6.0**
