### PR TITLE
Fix build error in guide

### DIFF
--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -1,3 +1,5 @@
+require 'action_view'
+
 module Helpers
   # This class exists purely to pass to render in format_slim, it doesn't appear
   # to matter what's passed in so long as the first arg responds to #variants


### PR DESCRIPTION
This happened because I upgraded the version of Ruby Netlify was configured to use for the build from 3.x to 4.0.2.