### PR TITLE
Update dependency on view_component

### DIFF
--- a/govuk-components.gemspec
+++ b/govuk-components.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "html-attributes-utils", "~> 1.0.0", ">= 1.0.0"
   spec.add_dependency "pagy", ">= 6", "< 10"
-  spec.add_dependency "view_component", ">= 4.0", "< 4.7"
+  spec.add_dependency "view_component", ">= 4.9", "< 4.10"
 
   spec.add_development_dependency "deep_merge"
   spec.add_development_dependency "ostruct"


### PR DESCRIPTION
Two medium level vunlerabilities are fixes in version 4.9.0. This commit ensures that the fixed version is used. See https://github.com/ViewComponent/view_component/releases/tag/v4.9.0 for details.

This will also pull in the changes made in version 4.8.0. See https://github.com/ViewComponent/view_component/releases/tag/v4.8.0

Although specifying the version as `">= 4.9", "< 4.10"` is effectively the same as `"= 4.9"`, this style is maintained to be clear for later updates.