### PR TITLE
Update footer to use V6 HTML

### DIFF
--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.footer(role: 'contentinfo', **html_attributes) do %>
+<%= tag.div(**html_attributes) do %>
   <%= tag.div(**container_html_attributes) do %>
     <%= tag.svg(class: "#{brand}-footer__crown", focusable: "false", role: "presentation", xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 64 60", height: "30", width: "32", fill: "currentColor") do %>
       <g>

--- a/guide/content/components/footer.slim
+++ b/guide/content/components/footer.slim
@@ -6,6 +6,8 @@ markdown:
   The footer provides copyright, licensing and other information about your
   service and department.
 
+  The component should always be rendered inside a HTML `footer` element.
+
 == render('/partials/example.*',
   caption: "Default footer",
   code: footer_normal) do

--- a/guide/layouts/default.slim
+++ b/guide/layouts/default.slim
@@ -18,4 +18,5 @@ html.govuk-template lang="en"
 
               == yield
 
-    == render '/partials/footer.*'
+    govuk-template__footer
+      == render '/partials/footer.*'

--- a/guide/layouts/partials/footer.slim
+++ b/guide/layouts/partials/footer.slim
@@ -1,4 +1,4 @@
-footer.govuk-footer
+.govuk-footer
   .govuk-width-container
     == render '/partials/x-govuk-crown.*'
     .govuk-footer__meta

--- a/guide/layouts/splash.slim
+++ b/guide/layouts/splash.slim
@@ -8,4 +8,5 @@ html.govuk-template lang="en"
     main#main-content
       == yield
 
-    == render '/partials/footer.*'
+    footer.govuk-template__footer
+      == render '/partials/footer.*'

--- a/spec/components/govuk_component/configuration/footer_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/footer_component_configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(GovukComponent::FooterComponent, type: :component) do
-  let(:selector) { "footer.govuk-footer .govuk-width-container .govuk-footer__meta" }
+  let(:selector) { "div.govuk-footer .govuk-width-container .govuk-footer__meta" }
   let(:kwargs) { {} }
 
   describe 'configuration' do

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   let(:kwargs) { {} }
   let(:meta_items_title) { 'Useful things' }
   let(:meta_licence) { 'MIT' }
-  let(:selector) { "footer.govuk-footer .govuk-width-container .govuk-footer__meta" }
+  let(:selector) { "div.govuk-footer .govuk-width-container .govuk-footer__meta" }
 
   let(:default_licence_text) { /All content is available under/ }
 
@@ -19,14 +19,14 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
     render_inline(GovukComponent::FooterComponent.new(**kwargs))
   end
 
-  specify 'renders a footer element' do
-    expect(rendered_content).to have_tag("footer", with: { class: component_css_class })
+  specify 'renders a div element' do
+    expect(rendered_content).to have_tag("div", with: { class: component_css_class })
   end
 
   specify 'the footer contains licencing information and a link to the OGL licence' do
     expected_link = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 
-    expect(rendered_content).to have_tag('footer', with: { class: 'govuk-footer' }) do
+    expect(rendered_content).to have_tag('div', with: { class: 'govuk-footer' }) do
       with_tag('div', with: { class: 'govuk-footer__meta' }) do
         with_tag('span', with: { class: 'govuk-footer__licence-description' }, text: default_licence_text) do
           with_tag('a', with: { href: expected_link }, text: "Open Government Licence v3.0")
@@ -36,7 +36,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   end
 
   specify 'the OGL logo is present' do
-    expect(rendered_content).to have_tag('footer', with: { class: component_css_class }) do
+    expect(rendered_content).to have_tag('div', with: { class: component_css_class }) do
       with_tag("div", with: { class: "govuk-footer__meta" }) do
         with_tag("svg", with: { class: "govuk-footer__licence-logo", 'aria-hidden' => true })
         expect(html).to contain_svgs_with_viewBox_attributes
@@ -160,7 +160,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
         end
 
         specify "the licence SVG is not rendered" do
-          expect(rendered_content).to have_tag("footer", with: { class: "govuk-footer" }) do
+          expect(rendered_content).to have_tag("div", with: { class: "govuk-footer" }) do
             with_tag("div", with: { class: "govuk-footer__meta" }) do
               without_tag("svg")
             end
@@ -186,7 +186,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
         end
 
         specify "the licence SVG is not rendered" do
-          expect(rendered_content).to have_tag("footer", with: { class: "govuk-footer" }) do
+          expect(rendered_content).to have_tag("div", with: { class: "govuk-footer" }) do
             with_tag("div", with: { class: "govuk-footer__meta" }) do
               without_tag("svg")
             end

--- a/spec/dummy/app/views/layouts/application.html.erb
+++ b/spec/dummy/app/views/layouts/application.html.erb
@@ -20,9 +20,11 @@
         <%= yield %>
       </main>
     </div>
-    <%= govuk_footer(meta_items: { "GitHub" => "https://github.com/x-govuk/govuk-components", "RubyGems" => "https://rubygems.org/gems/govuk-components", "DfE Digital" => "https://dfedigital.blog.gov.uk/" }) %>
-  <script>
-    window.GOVUKFrontend.initAll();
-  </script>
+    <footer class="govuk-template__footer">
+      <%= govuk_footer(meta_items: { "GitHub" => "https://github.com/x-govuk/govuk-components", "RubyGems" => "https://rubygems.org/gems/govuk-components", "DfE Digital" => "https://dfedigital.blog.gov.uk/" }) %>
+    </footer>
+    <script>
+      window.GOVUKFrontend.initAll();
+    </script>
   </body>
 </html>


### PR DESCRIPTION
Decouples the footer component from the HTML footer element, following the [corresponding change in govuk-frontend v6](https://github.com/alphagov/govuk-frontend/pull/6537).

Implements #641 