### PR TITLE
Update the footer to use v6 markdup

### DIFF
--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.footer do %>
+<%= tag.footer(**footer_attributes) do %>
   <%= content %>
   <%= tag.div(role: 'contentinfo', **html_attributes) do %>
     <%= tag.div(**container_html_attributes) do %>

--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -1,63 +1,65 @@
-<%= tag.footer(role: 'contentinfo', **html_attributes) do %>
-  <%= tag.div(**container_html_attributes) do %>
-    <%= tag.svg(class: "#{brand}-footer__crown", focusable: "false", role: "presentation", xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 64 60", height: "30", width: "32", fill: "currentColor") do %>
-      <g>
-        <circle cx="20" cy="17.6" r="3.7"/>
-        <circle cx="10.2" cy="23.5" r="3.7"/>
-        <circle cx="3.7" cy="33.2" r="3.7"/>
-        <circle cx="31.7" cy="30.6" r="3.7"/>
-        <circle cx="43.3" cy="17.6" r="3.7"/>
-        <circle cx="53.2" cy="23.5" r="3.7"/>
-        <circle cx="59.7" cy="33.2" r="3.7"/>
-        <circle cx="31.7" cy="30.6" r="3.7"/>
-        <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z"/>
-      </g>
-    <% end %>
+<%= tag.footer do %>
+  <%= tag.div(role: 'contentinfo', **html_attributes) do %>
+    <%= tag.div(**container_html_attributes) do %>
+      <%= tag.svg(class: "#{brand}-footer__crown", focusable: "false", role: "presentation", xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 64 60", height: "30", width: "32", fill: "currentColor") do %>
+        <g>
+          <circle cx="20" cy="17.6" r="3.7"/>
+          <circle cx="10.2" cy="23.5" r="3.7"/>
+          <circle cx="3.7" cy="33.2" r="3.7"/>
+          <circle cx="31.7" cy="30.6" r="3.7"/>
+          <circle cx="43.3" cy="17.6" r="3.7"/>
+          <circle cx="53.2" cy="23.5" r="3.7"/>
+          <circle cx="59.7" cy="33.2" r="3.7"/>
+          <circle cx="31.7" cy="30.6" r="3.7"/>
+          <path d="M33.1,9.8c.2-.1.3-.3.5-.5l4.6,2.4v-6.8l-4.6,1.5c-.1-.2-.3-.3-.5-.5l1.9-5.9h-6.7l1.9,5.9c-.2.1-.3.3-.5.5l-4.6-1.5v6.8l4.6-2.4c.1.2.3.3.5.5l-2.6,8c-.9,2.8,1.2,5.7,4.1,5.7h0c3,0,5.1-2.9,4.1-5.7l-2.6-8ZM37,37.9s-3.4,3.8-4.1,6.1c2.2,0,4.2-.5,6.4-2.8l-.7,8.5c-2-2.8-4.4-4.1-5.7-3.8.1,3.1.5,6.7,5.8,7.2,3.7.3,6.7-1.5,7-3.8.4-2.6-2-4.3-3.7-1.6-1.4-4.5,2.4-6.1,4.9-3.2-1.9-4.5-1.8-7.7,2.4-10.9,3,4,2.6,7.3-1.2,11.1,2.4-1.3,6.2,0,4,4.6-1.2-2.8-3.7-2.2-4.2.2-.3,1.7.7,3.7,3,4.2,1.9.3,4.7-.9,7-5.9-1.3,0-2.4.7-3.9,1.7l2.4-8c.6,2.3,1.4,3.7,2.2,4.5.6-1.6.5-2.8,0-5.3l5,1.8c-2.6,3.6-5.2,8.7-7.3,17.5-7.4-1.1-15.7-1.7-24.5-1.7h0c-8.8,0-17.1.6-24.5,1.7-2.1-8.9-4.7-13.9-7.3-17.5l5-1.8c-.5,2.5-.6,3.7,0,5.3.8-.8,1.6-2.3,2.2-4.5l2.4,8c-1.5-1-2.6-1.7-3.9-1.7,2.3,5,5.2,6.2,7,5.9,2.3-.4,3.3-2.4,3-4.2-.5-2.4-3-3.1-4.2-.2-2.2-4.6,1.6-6,4-4.6-3.7-3.7-4.2-7.1-1.2-11.1,4.2,3.2,4.3,6.4,2.4,10.9,2.5-2.8,6.3-1.3,4.9,3.2-1.8-2.7-4.1-1-3.7,1.6.3,2.3,3.3,4.1,7,3.8,5.4-.5,5.7-4.2,5.8-7.2-1.3-.2-3.7,1-5.7,3.8l-.7-8.5c2.2,2.3,4.2,2.7,6.4,2.8-.7-2.3-4.1-6.1-4.1-6.1h10.6,0Z"/>
+        </g>
+      <% end %>
 
-    <% if navigation.present? %>
-      <div class="<%= brand %>-footer__navigation">
-        <%= navigation %>
-      </div>
-
-      <%= tag.hr(class: "#{brand}-footer__section-break") %>
-    <% end %>
-
-    <%= tag.div(class: meta_classes, **meta_html_attributes) do %>
-      <% if meta.present? %>
-        <%= meta %>
-      <% else %>
-        <div class="<%= brand %>-footer__meta-item <%= brand %>-footer__meta-item--grow">
-          <% if meta_items.any? %>
-            <h2 class="<%= brand %>-visually-hidden"><%= meta_items_title %></h2>
-            <%= content_before_meta_items %>
-            <ul class="<%= brand %>-footer__inline-list">
-              <% @meta_items.each do |hyperlink| %>
-                <li class="<%= brand %>-footer__inline-list-item">
-                  <%= hyperlink %>
-                </li>
-              <% end %>
-            </ul>
-            <%= content_after_meta_items %>
-          <% end %>
-
-          <% if meta_content.present? %>
-            <div class="<%= brand %>-footer__meta-custom">
-              <%= meta_content %>
-            </div>
-          <% end %>
-
-          <% if meta_licence_content.nil? %>
-            <svg aria-hidden="true" focusable="false" class="<%= brand %>-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
-              <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"/>
-            </svg>
-
-            <%= tag.span(default_licence, class: "#{brand}-footer__licence-description") %>
-          <% elsif meta_licence_content.present? %>
-            <%= tag.span(meta_licence_content, class: "#{brand}-footer__licence-description") %>
-          <% end %>
+      <% if navigation.present? %>
+        <div class="<%= brand %>-footer__navigation">
+          <%= navigation %>
         </div>
 
-        <%= tag.div(copyright, class: "#{brand}-footer__meta-item") %>
+        <%= tag.hr(class: "#{brand}-footer__section-break") %>
+      <% end %>
+
+      <%= tag.div(class: meta_classes, **meta_html_attributes) do %>
+        <% if meta.present? %>
+          <%= meta %>
+        <% else %>
+          <div class="<%= brand %>-footer__meta-item <%= brand %>-footer__meta-item--grow">
+            <% if meta_items.any? %>
+              <h2 class="<%= brand %>-visually-hidden"><%= meta_items_title %></h2>
+              <%= content_before_meta_items %>
+              <ul class="<%= brand %>-footer__inline-list">
+                <% @meta_items.each do |hyperlink| %>
+                  <li class="<%= brand %>-footer__inline-list-item">
+                    <%= hyperlink %>
+                  </li>
+                <% end %>
+              </ul>
+              <%= content_after_meta_items %>
+            <% end %>
+
+            <% if meta_content.present? %>
+              <div class="<%= brand %>-footer__meta-custom">
+                <%= meta_content %>
+              </div>
+            <% end %>
+
+            <% if meta_licence_content.nil? %>
+              <svg aria-hidden="true" focusable="false" class="<%= brand %>-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+                <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"/>
+              </svg>
+
+              <%= tag.span(default_licence, class: "#{brand}-footer__licence-description") %>
+            <% elsif meta_licence_content.present? %>
+              <%= tag.span(meta_licence_content, class: "#{brand}-footer__licence-description") %>
+            <% end %>
+          </div>
+
+          <%= tag.div(copyright, class: "#{brand}-footer__meta-item") %>
+        <% end %>
       <% end %>
     <% end %>
   <% end %>

--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -1,4 +1,5 @@
 <%= tag.footer do %>
+  <%= content %>
   <%= tag.div(role: 'contentinfo', **html_attributes) do %>
     <%= tag.div(**container_html_attributes) do %>
       <%= tag.svg(class: "#{brand}-footer__crown", focusable: "false", role: "presentation", xmlns: "http://www.w3.org/2000/svg", viewBox: "0 0 64 60", height: "30", width: "32", fill: "currentColor") do %>

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -10,7 +10,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
   renders_one :content_after_meta_items
   renders_one :meta_licence_html
 
-  attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright_text, :copyright_url, :custom_container_classes
+  attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright_text, :copyright_url, :custom_container_classes, :footer_attributes
 
   def initialize(
     classes: [],
@@ -18,6 +18,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     container_html_attributes: {},
     copyright_text: config.default_footer_copyright_text,
     copyright_url: config.default_footer_copyright_url,
+    footer_attributes: {},
     html_attributes: {},
     meta_items: {},
     meta_items_title: "Support links",
@@ -36,6 +37,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     @copyright_url                    = copyright_url
     @custom_container_classes         = container_classes
     @custom_container_html_attributes = container_html_attributes
+    @footer_attributes                = footer_attributes
 
     super(classes:, html_attributes:)
   end

--- a/guide/content/components/footer.slim
+++ b/guide/content/components/footer.slim
@@ -63,4 +63,10 @@ markdown:
   caption: "Footer with navigation",
   code: footer_with_navigation)
 
+== render('/partials/example.*',
+  caption: "Footer with content above",
+  code: footer_with_content_above) do
+  markdown:
+    You can place content inside the `<footer>` element before the GOV.UK footer by passing it in as a block of HTML.
+
 == render('/partials/related-navigation.*', links: footer_info)

--- a/guide/lib/examples/footer_helpers.rb
+++ b/guide/lib/examples/footer_helpers.rb
@@ -107,5 +107,12 @@ module Examples
                 li == govuk_footer_link_to("Tenth", "#")
       FOOTER_WITH_NAVIGATION
     end
+
+    def footer_with_content_above
+      <<~FOOTER_WITH_CONTENT_ABOVE
+        = govuk_footer do
+          = govuk_phase_banner(tag: { text: "Beta", colour: "red" }, text: "This is a new service")
+      FOOTER_WITH_CONTENT_ABOVE
+    end
   end
 end

--- a/spec/components/govuk_component/configuration/footer_component_configuration_spec.rb
+++ b/spec/components/govuk_component/configuration/footer_component_configuration_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe(GovukComponent::FooterComponent, type: :component) do
-  let(:selector) { "footer.govuk-footer .govuk-width-container .govuk-footer__meta" }
+  let(:selector) { "footer > div.govuk-footer .govuk-width-container .govuk-footer__meta" }
   let(:kwargs) { {} }
 
   describe 'configuration' do

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -344,4 +344,26 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
       expect(rendered_content).to have_tag("hr", with: { class: "govuk-footer__section-break" })
     end
   end
+
+  describe "adding custom content above the footer" do
+    let(:custom_class) { 'before-footer' }
+    let(:custom_text) { 'this appears in the footer element above the rest of the content' }
+    let(:custom_html) { helper.tag.h3(custom_text, class: 'before-footer') }
+
+    subject! do
+      render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |component|
+        custom_html
+      end
+    end
+
+    it 'renders the custom html' do
+      expect(rendered_content).to have_tag('footer > h3', text: custom_text)
+    end
+
+    it 'renders the custom html above the GOV.UK footer content' do
+      classes = html.css("footer").children.map { |n| n['class'] }.compact
+
+      expect(classes).to eql([custom_class, component_css_class])
+    end
+  end
 end

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -7,7 +7,10 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   let(:kwargs) { {} }
   let(:meta_items_title) { 'Useful things' }
   let(:meta_licence) { 'MIT' }
-  let(:selector) { "footer.govuk-footer .govuk-width-container .govuk-footer__meta" }
+
+  let(:footer_selector) { "footer > div.govuk-footer" }
+  let(:meta_selector) { "#{footer_selector} .govuk-width-container .govuk-footer__meta" }
+  let(:licence_selector) { "#{meta_selector} .govuk-footer__licence-description" }
 
   let(:default_licence_text) { /All content is available under/ }
 
@@ -19,14 +22,14 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
     render_inline(GovukComponent::FooterComponent.new(**kwargs))
   end
 
-  specify 'renders a footer element' do
-    expect(rendered_content).to have_tag("footer", with: { class: component_css_class })
+  specify 'renders a footer element containing a div with the footer class' do
+    expect(rendered_content).to have_tag(footer_selector, with: { class: component_css_class })
   end
 
   specify 'the footer contains licencing information and a link to the OGL licence' do
     expected_link = "https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
 
-    expect(rendered_content).to have_tag('footer', with: { class: 'govuk-footer' }) do
+    expect(rendered_content).to have_tag(footer_selector, with: { class: 'govuk-footer' }) do
       with_tag('div', with: { class: 'govuk-footer__meta' }) do
         with_tag('span', with: { class: 'govuk-footer__licence-description' }, text: default_licence_text) do
           with_tag('a', with: { href: expected_link }, text: "Open Government Licence v3.0")
@@ -36,7 +39,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   end
 
   specify 'the OGL logo is present' do
-    expect(rendered_content).to have_tag('footer', with: { class: component_css_class }) do
+    expect(rendered_content).to have_tag(footer_selector, with: { class: component_css_class }) do
       with_tag("div", with: { class: "govuk-footer__meta" }) do
         with_tag("svg", with: { class: "govuk-footer__licence-logo", 'aria-hidden' => true })
         expect(html).to contain_svgs_with_viewBox_attributes
@@ -54,7 +57,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   end
 
   specify "the copyright information is present" do
-    expect(rendered_content).to have_tag(selector) do
+    expect(rendered_content).to have_tag(meta_selector) do
       with_tag("div", with: { class: "govuk-footer__meta-item" }, text: /Crown copyright/)
       with_tag("a", with: { class: %w(govuk-footer__link govuk-footer__copyright-logo) })
     end
@@ -82,7 +85,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
         end
 
         specify "each meta item is listed" do
-          expect(rendered_content).to have_tag(selector) do
+          expect(rendered_content).to have_tag(meta_selector) do
             with_tag("li > a", count: meta_items.size)
 
             meta_items.each do |text, href|
@@ -105,7 +108,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
         let(:kwargs) { { meta_items_title: heading_text, meta_items: } }
 
         specify "each meta item is rendered" do
-          expect(rendered_content).to have_tag(selector) do
+          expect(rendered_content).to have_tag(meta_selector) do
             with_tag("li > a", count: meta_items.size)
 
             meta_items.each do |item|
@@ -149,8 +152,6 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
     end
 
     describe "custom licence content" do
-      let(:licence_selector) { [selector, ".govuk-footer__licence-description"].join(" ") }
-
       describe "meta_licence" do
         let(:licence_text) { "Permission is hereby granted, free of charge, to any person obtaining a copy of this software" }
         let(:kwargs) { { meta_licence: licence_text } }
@@ -160,7 +161,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
         end
 
         specify "the licence SVG is not rendered" do
-          expect(rendered_content).to have_tag("footer", with: { class: "govuk-footer" }) do
+          expect(rendered_content).to have_tag(footer_selector, with: { class: "govuk-footer" }) do
             with_tag("div", with: { class: "govuk-footer__meta" }) do
               without_tag("svg")
             end
@@ -186,7 +187,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
         end
 
         specify "the licence SVG is not rendered" do
-          expect(rendered_content).to have_tag("footer", with: { class: "govuk-footer" }) do
+          expect(rendered_content).to have_tag(footer_selector, with: { class: "govuk-footer" }) do
             with_tag("div", with: { class: "govuk-footer__meta" }) do
               without_tag("svg")
             end
@@ -216,7 +217,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
 
     describe "when custom meta_licence text is disabled" do
       let(:kwargs) { { meta_licence: false } }
-      let(:licence_selector) { [selector, ".govuk-footer__licence-description"].join(" ") }
+      let(:licence_selector) { [meta_selector, ".govuk-footer__licence-description"].join(" ") }
 
       specify "the licence text not should be rendered" do
         expect(rendered_content).not_to have_tag(licence_selector)
@@ -233,11 +234,11 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
       end
 
       specify "the content should be rendered" do
-        expect(rendered_content).to have_tag(selector, text: Regexp.new(custom_content))
+        expect(rendered_content).to have_tag(meta_selector, text: Regexp.new(custom_content))
       end
 
       specify "the licence, meta items and header should still be rendered" do
-        expect(rendered_content).to have_tag(selector) do
+        expect(rendered_content).to have_tag(meta_selector) do
           with_tag("h2", text: heading_text)
           with_tag("ul", with: { class: "govuk-footer__inline-list" })
           with_tag("span", with: { class: "govuk-footer__licence-description" }, text: default_licence_text)
@@ -292,11 +293,11 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
     end
 
     specify "the custom content should be rendered" do
-      expect(rendered_content).to have_tag(selector, text: Regexp.new(custom_content))
+      expect(rendered_content).to have_tag(meta_selector, text: Regexp.new(custom_content))
     end
 
     specify "the licence, meta items and header shouldn't be rendered" do
-      expect(rendered_content).to have_tag(selector) do
+      expect(rendered_content).to have_tag(meta_selector) do
         without_tag("h2")
         without_tag("ul")
         without_tag("span")
@@ -310,7 +311,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
     let(:kwargs) { { copyright_text:, copyright_url: } }
 
     specify "the custom copyright text and link are rendered" do
-      expect(rendered_content).to have_tag(selector) do
+      expect(rendered_content).to have_tag(meta_selector) do
         with_tag("div", with: { class: "govuk-footer__meta-item" }, text: Regexp.new(copyright_text))
         with_tag("a", text: copyright_text, with: { href: copyright_url })
       end

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -351,7 +351,7 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
     let(:custom_html) { helper.tag.h3(custom_text, class: 'before-footer') }
 
     subject! do
-      render_inline(GovukComponent::FooterComponent.new(**kwargs)) do |component|
+      render_inline(GovukComponent::FooterComponent.new(**kwargs)) do
         custom_html
       end
     end
@@ -364,6 +364,19 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
       classes = html.css("footer").children.map { |n| n['class'] }.compact
 
       expect(classes).to eql([custom_class, component_css_class])
+    end
+  end
+
+  describe "adding custom attributes to the footer element" do
+    let(:footer_attributes) { { lang: 'es', class: 'purple' } }
+    let(:kwargs) { { footer_attributes: } }
+
+    subject! do
+      render_inline(GovukComponent::FooterComponent.new(**kwargs))
+    end
+
+    it "renders the footer wth custom attributes" do
+      expect(rendered_content).to have_tag('footer', with: footer_attributes)
     end
   end
 end


### PR DESCRIPTION
Version 6 of the Design System [moved the footer component to a div inside the `<footer>` element](https://github.com/alphagov/govuk-frontend/pull/6537), rather than it being _the_ `<footer>` element.

This change makes the same change here, but it works in the same way as the corresponding change to the header component (#626) rather than like the upstream Nunjucks implementation.

The `govuk_footer` component still renders the `<footer>` element and places the GOV.UK footer `<div>` within it. It now supports taking a block of arbitrary HTML which is rendered inside the `<footer>` but above the `<div>` that contains the GOV.UK footer.

<img width="804" height="481" alt="screengrab showing a govuk footer component with a red 'Beta' phase banner rendered immediately above it" src="https://github.com/user-attachments/assets/1f06b15c-bc66-4f44-95b9-b9badeb94c3a" />

Custom attributes can be set on the `<footer>` element by passing in a hash to `footer_attributes`.
