### PR TITLE
Allow header element to have custom attributes set

### DIFF
--- a/app/components/govuk_component/header_component.html.erb
+++ b/app/components/govuk_component/header_component.html.erb
@@ -1,4 +1,4 @@
-<header>
+<%= tag.header(**header_html_attributes) do %>
   <%= tag.div(data: { module: "#{brand}-header" }, **html_attributes) do %>
     <%= tag.div(**container_html_attributes) do %>
       <div class="<%= brand %>-header__logo">
@@ -41,4 +41,4 @@
   <% end %>
   <%= service_navigation %>
   <%= phase_banner %>
-</header>
+<% end %>

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -9,14 +9,16 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
               :service_url,
               :menu_button_label,
               :custom_container_classes,
-              :full_width_border
+              :full_width_border,
+              :header_html_attributes
 
   def initialize(classes: [],
                  html_attributes: {},
                  homepage_url: config.default_header_homepage_url,
                  menu_button_label: config.default_header_menu_button_label,
                  container_classes: nil,
-                 full_width_border: false)
+                 full_width_border: false,
+                 header_html_attributes: {})
 
     @homepage_url              = homepage_url
     @service_name              = service_name
@@ -24,6 +26,7 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
     @menu_button_label         = menu_button_label
     @custom_container_classes  = container_classes
     @full_width_border         = full_width_border
+    @header_html_attributes    = header_html_attributes
 
     super(classes:, html_attributes:)
   end

--- a/spec/components/govuk_component/header_component_spec.rb
+++ b/spec/components/govuk_component/header_component_spec.rb
@@ -5,9 +5,10 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
   let(:product_name) { 'Order an amazing ID' }
   let(:logotype) { 'OMG.UK' }
   let(:homepage_url) { 'https://omg.uk/bbq' }
+  let(:header_html_attributes) { {} }
 
   let(:all_kwargs) do
-    { homepage_url:, }
+    { homepage_url:, header_html_attributes: }
   end
   let(:kwargs) { all_kwargs }
 
@@ -75,6 +76,14 @@ RSpec.describe(GovukComponent::HeaderComponent, type: :component) do
 
     specify "doesn't render the default logotype" do
       expect(rendered_content).not_to have_tag("span", text: /GOV.UK/)
+    end
+  end
+
+  context 'when header html attributes are provided' do
+    let(:header_html_attributes) { { class: 'header-inverse', lang: 'de' } }
+
+    specify 'the outer header element has the custom attributes' do
+      expect(rendered_content).to have_tag('header', with: { class: 'header-inverse', lang: 'de' })
     end
   end
 


### PR DESCRIPTION
This small tweak allows custom attributes to be set on the `<header>` element that surrounds the GOV.UK header.

It'll be useful when building pages that have inverted colours, like landing pages with mastheads.