### PR TITLE
Generic header

### DIFF
--- a/app/components/govuk_component/generic_header_component.html.erb
+++ b/app/components/govuk_component/generic_header_component.html.erb
@@ -1,0 +1,18 @@
+<%= tag.header(**header_html_attributes) do %>
+  <%= tag.div(class: "#{brand}-generic-header", **html_attributes) do %>
+    <%= tag.div(class: ["#{brand}-generic-header__container", "#{brand}-width-container"]) do %>
+      <%= tag.div(class: "#{brand}-generic-header__logo") do %>
+        <%=
+          case
+          when logo.present? then logo
+          when url.present? then link_to(logo_text, url, class: "#{brand}-generic-header__homepage-link")
+          else logo_text
+          end
+        %>
+      <% end %>
+      <%= content %>
+    <% end %>
+  <% end %>
+  <%= service_navigation %>
+  <%= phase_banner %>
+<% end %>

--- a/app/components/govuk_component/generic_header_component.rb
+++ b/app/components/govuk_component/generic_header_component.rb
@@ -1,0 +1,36 @@
+class GovukComponent::GenericHeaderComponent < GovukComponent::Base
+  renders_one :logo
+  renders_one :service_navigation, "GovukComponent::ServiceNavigationComponent"
+  renders_one :phase_banner, "GovukComponent::PhaseBannerComponent"
+
+  attr_reader :url,
+              :logo_text,
+              :menu_button_label,
+              :header_html_attributes
+
+  def initialize(url: nil,
+                 logo_text: nil,
+                 classes: [],
+                 html_attributes: {},
+                 header_html_attributes: {})
+
+    @url = url
+    @logo_text = logo_text
+    @header_html_attributes = header_html_attributes
+
+    super(classes:, html_attributes:)
+  end
+
+  def before_render
+    if logo.blank?
+      fail(ArgumentError, 'logo_text missing') if logo_text.blank?
+      fail(ArgumentError, 'url missing') if url.blank?
+    end
+  end
+
+private
+
+  def default_attributes
+    { class: class_names("#{brand}-generic-header") }
+  end
+end

--- a/app/components/govuk_component/header_component.rb
+++ b/app/components/govuk_component/header_component.rb
@@ -5,9 +5,7 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
   renders_one :phase_banner, "GovukComponent::PhaseBannerComponent"
 
   attr_reader :homepage_url,
-              :service_name,
               :service_url,
-              :menu_button_label,
               :custom_container_classes,
               :full_width_border,
               :header_html_attributes
@@ -15,15 +13,11 @@ class GovukComponent::HeaderComponent < GovukComponent::Base
   def initialize(classes: [],
                  html_attributes: {},
                  homepage_url: config.default_header_homepage_url,
-                 menu_button_label: config.default_header_menu_button_label,
                  container_classes: nil,
                  full_width_border: false,
                  header_html_attributes: {})
 
     @homepage_url              = homepage_url
-    @service_name              = service_name
-    @service_url               = service_url
-    @menu_button_label         = menu_button_label
     @custom_container_classes  = container_classes
     @full_width_border         = full_width_border
     @header_html_attributes    = header_html_attributes

--- a/app/helpers/govuk_components_helper.rb
+++ b/app/helpers/govuk_components_helper.rb
@@ -7,6 +7,7 @@ module GovukComponentsHelper
     govuk_details: 'GovukComponent::DetailsComponent',
     govuk_exit_this_page: 'GovukComponent::ExitThisPageComponent',
     govuk_footer: 'GovukComponent::FooterComponent',
+    govuk_generic_header: 'GovukComponent::GenericHeaderComponent',
     govuk_header: 'GovukComponent::HeaderComponent',
     govuk_inset_text: 'GovukComponent::InsetTextComponent',
     govuk_notification_banner: 'GovukComponent::NotificationBannerComponent',

--- a/guide/content/components/generic-header.slim
+++ b/guide/content/components/generic-header.slim
@@ -1,0 +1,36 @@
+---
+title: Generic header
+---
+
+markdown:
+  If your service is public-facing and isn't on GOV.UK, use the generic header
+  instead of the [GOV.UK header](/components/header/).
+
+== render('/partials/example.*',
+  caption: "Generic header with logo text and URL",
+  code: generic_header_with_logo_text_and_url)
+
+== render('/partials/example.*',
+  caption: "Generic header with a custom logo",
+  code: generic_header_with_custom_logo)
+
+== render('/partials/example.*',
+  caption: "Generic header with custom content",
+  code: generic_header_with_custom_content) do
+
+  markdown:
+    Any HTML passed into the component's block will be rendered inside the
+    header after the logo.
+
+    It will need custom CSS to position it.
+
+== render('/partials/example.*',
+  caption: "Generic header with service navigation and a phase banner",
+  code: generic_header_with_service_navigation_and_phase_banner) do
+
+  markdown:
+    Like with the [GOV.UK header](/components/header/), the header is rendered
+    inside a `<header>` element. Service navigation and phase banner components
+    can be rendered beneath using slots.
+
+== render('/partials/related-navigation.*', links: generic_header_info)

--- a/guide/content/stylesheets/preview.scss
+++ b/guide/content/stylesheets/preview.scss
@@ -80,6 +80,15 @@
   }
 }
 
+.govuk-generic-header.with-username > .govuk-generic-header__container {
+  display: flex;
+  align-items: center;
+
+  .govuk-generic-header__logo {
+    flex-grow: 1;
+  }
+}
+
 // Example custom logo used in documentation
 .app-header__logotype {
   fill: #00ffe0;

--- a/guide/lib/examples/generic_header_helpers.rb
+++ b/guide/lib/examples/generic_header_helpers.rb
@@ -1,0 +1,33 @@
+module Examples
+  module GenericHeaderHelpers
+    def generic_header_with_logo_text_and_url
+      <<~GENERIC_HEADER
+        = govuk_generic_header(logo_text: 'A generic service', url: '/')
+      GENERIC_HEADER
+    end
+
+    def generic_header_with_custom_logo
+      <<~GENERIC_HEADER
+        = govuk_generic_header do |header|
+          - header.with_logo do
+            a href='/' class='govuk-generic-header__homepage-link'
+              | 🩵 My generic service
+      GENERIC_HEADER
+    end
+
+    def generic_header_with_custom_content
+      <<~GENERIC_HEADER
+        = govuk_generic_header(logo_text: 'A generic service', url: '/', html_attributes: { class: 'with-username' }) do
+          | Sign out
+      GENERIC_HEADER
+    end
+
+    def generic_header_with_service_navigation_and_phase_banner
+      <<~GENERIC_HEADER
+        = govuk_generic_header(logo_text: 'Some organisation', url: '/') do |header|
+          - header.with_service_navigation(service_name: 'Service navigation', service_url: '#')
+          - header.with_phase_banner(tag: { text: "Beta" }, text: "This is a generic service")
+      GENERIC_HEADER
+    end
+  end
+end

--- a/guide/lib/examples/phase_banner_helpers.rb
+++ b/guide/lib/examples/phase_banner_helpers.rb
@@ -2,7 +2,7 @@ module Examples
   module PhaseBannerHelpers
     def phase_banner_normal
       <<~PHASE_BANNER
-        = govuk_phase_banner(tag: { text: "Alpha" }, text: "This is a new service – your feedback will help us to improve it. ")
+        = govuk_phase_banner(tag: { text: "Alpha" }, text: "This is a new service – your feedback will help us to improve it.")
       PHASE_BANNER
     end
 

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -55,6 +55,7 @@ require 'components/govuk_component/cookie_banner_component/message_component'
 require 'components/govuk_component/details_component'
 require 'components/govuk_component/exit_this_page_component'
 require 'components/govuk_component/footer_component'
+require 'components/govuk_component/generic_header_component'
 require 'components/govuk_component/header_component'
 require 'components/govuk_component/inset_text_component'
 require 'components/govuk_component/notification_banner_component'
@@ -105,6 +106,7 @@ use_helper Examples::BackLinkHelpers
 use_helper Examples::CookieBannerHelpers
 use_helper Examples::DetailsHelpers
 use_helper Examples::FooterHelpers
+use_helper Examples::GenericHeaderHelpers
 use_helper Examples::HeaderHelpers
 use_helper Examples::InsetTextHelpers
 use_helper Examples::NotificationBannerHelpers

--- a/guide/lib/helpers/content_helpers.rb
+++ b/guide/lib/helpers/content_helpers.rb
@@ -119,6 +119,12 @@ module Helpers
       }
     end
 
+    def generic_header_info
+      {
+        "GOV.UK Design System generic header documentation" => "https://design-system.service.gov.uk/components/generic-header/"
+      }
+    end
+
   private
 
     def component_helper_mapping

--- a/guide/lib/helpers/link_helpers.rb
+++ b/guide/lib/helpers/link_helpers.rb
@@ -32,6 +32,7 @@ module Helpers
           "Cookie banner" => "/components/cookie-banner/",
           "Details" => "/components/details/",
           "Exit this page" => "/components/exit-this-page/",
+          "Generic header" => "/components/generic-header/",
           "GOV.UK footer" => "/components/footer/",
           "GOV.UK header" => "/components/header/",
           "Inset text" => "/components/inset-text/",

--- a/spec/components/govuk_component/generic_header_component_spec.rb
+++ b/spec/components/govuk_component/generic_header_component_spec.rb
@@ -1,0 +1,120 @@
+require 'spec_helper'
+
+RSpec.describe(GovukComponent::GenericHeaderComponent, type: :component) do
+  let(:component_css_class) { 'govuk-generic-header' }
+  let(:header_html_attributes) { {} }
+  let(:url) { "https://a-very-nice-website.example.org.uk" }
+  let(:logo_text) { "A very nice website" }
+
+  let(:logo_selector) do
+    %w[header
+       div.govuk-generic-header
+       div.govuk-generic-header__container
+       div.govuk-generic-header__logo].join(' > ')
+  end
+
+  let(:kwargs) { { url:, logo_text:, header_html_attributes: } }
+
+  subject! { render_inline(GovukComponent::GenericHeaderComponent.new(**kwargs)) }
+
+  it_behaves_like 'a component that accepts custom classes'
+  it_behaves_like 'a component that accepts custom HTML attributes'
+  it_behaves_like 'a component that supports custom branding'
+  it_behaves_like 'a component that supports brand overrides'
+
+  specify 'builds the header with the given link' do
+    expect(rendered_content).to have_tag(logo_selector) do
+      with_tag('a', with: { href: url }, text: logo_text)
+    end
+  end
+
+  context 'when header html attributes are provided' do
+    let(:header_html_attributes) { { class: 'header-yellow', lang: 'fi' } }
+
+    specify 'the outer header element has the custom attributes' do
+      expect(rendered_content).to have_tag('header', with: { class: 'header-yellow', lang: 'fi' })
+    end
+  end
+
+  context 'when a custom logo is provided' do
+    let(:logo_text) { '' }
+    let(:custom_logo) { %(<span class="custom-logo">Custom logo</span>) }
+
+    subject! do
+      render_inline(GovukComponent::GenericHeaderComponent.new(**kwargs)) do |header|
+        header.with_logo { custom_logo.html_safe }
+      end
+    end
+
+    specify 'renders the logo' do
+      expect(rendered_content).to have_tag(logo_selector) do
+        with_tag('span', with: { class: 'custom-logo' }, text: 'Custom logo')
+      end
+    end
+  end
+
+  context 'when no logo or url is supplied' do
+    specify 'an argument error is thrown' do
+      failing_component = GovukComponent::GenericHeaderComponent.new(url: '', logo_text: 'test')
+
+      expect { render_inline(failing_component) }.to raise_error(ArgumentError, /url missing/)
+    end
+  end
+
+  context 'when neither a logo or logo_text is supplied' do
+    specify 'an argument error is thrown' do
+      failing_component = GovukComponent::GenericHeaderComponent.new(logo_text: '')
+
+      expect { render_inline(failing_component) }.to raise_error(ArgumentError, /logo_text missing/)
+    end
+  end
+
+  describe 'rendering service navigation within the header' do
+    subject! do
+      render_inline(GovukComponent::GenericHeaderComponent.new(**kwargs)) do |header|
+        header.with_service_navigation(service_name: "My new service", service_url: "#")
+      end
+    end
+
+    specify 'the service navigation component is rendered within the header element' do
+      expect(rendered_content).to have_tag('header') do
+        with_tag('section', with: { class: 'govuk-service-navigation' }) do
+          with_tag('a', text: 'My new service', href: '#')
+        end
+      end
+    end
+  end
+
+  describe 'rendering phase banner within the header' do
+    subject! do
+      render_inline(GovukComponent::GenericHeaderComponent.new(**kwargs)) do |header|
+        header.with_phase_banner(tag: { text: 'Alpha' }, text: 'This is a brand new service')
+      end
+    end
+
+    specify 'the service navigation component is rendered within the header element' do
+      expect(rendered_content).to have_tag('header') do
+        with_tag('div', with: { class: 'govuk-phase-banner' }) do
+          with_tag('strong', text: 'Alpha')
+          with_text('This is a brand new service')
+        end
+      end
+    end
+  end
+
+  describe 'rendering arbitrary content within the header' do
+    subject! do
+      render_inline(GovukComponent::GenericHeaderComponent.new(**kwargs)) do
+        '<nav>Navigation goes here</nav>'.html_safe
+      end
+    end
+
+    specify 'the service navigation component is rendered within the header element' do
+      expect(rendered_content).to have_tag('header') do
+        with_tag('div', with: { class: 'govuk-generic-header' }) do
+          with_tag('nav', text: 'Navigation goes here')
+        end
+      end
+    end
+  end
+end

--- a/spec/helpers/govuk_components_helper_spec.rb
+++ b/spec/helpers/govuk_components_helper_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe(GovukComponentsHelper, type: 'helper') do
       css_matcher: %(.govuk-header)
     },
     {
+      helper_method: :govuk_generic_header,
+      klass: GovukComponent::GenericHeaderComponent,
+      args: [],
+      kwargs: { url: '/', logo_text: 'Some logo' },
+      css_matcher: %(.govuk-generic-header)
+    },
+    {
       helper_method: :govuk_inset_text,
       klass: GovukComponent::InsetTextComponent,
       args: [],


### PR DESCRIPTION
This component was added in [govuk-frontend 6.3.0](https://github.com/alphagov/govuk-frontend/releases/tag/v6.3.0) and provides an alternative header for websites/services that aren't on GOV.UK.

Like the GOV.UK header component (but unlike the upstream Nunjucks component), it does render the outer `<header>` element and it provides slots to render the service navigation and phase banner inside it.

## Guide preview

| With custom logo | With service nav and phase banner |
| ------ | ------- |
| <img width="857" height="623" alt="Screenshot From 2026-06-29 20-34-03" src="https://github.com/user-attachments/assets/f3d55b90-8985-409c-9a07-e1c08a5e06ae" /> | <img width="874" height="842" alt="Screenshot From 2026-06-29 20-33-52" src="https://github.com/user-attachments/assets/e092ab3f-856b-4b36-8dab-afdeef1d4cd7" /> |