### PR TITLE
Interruption panels

### DIFF
--- a/app/components/govuk_component/panel_component.html.erb
+++ b/app/components/govuk_component/panel_component.html.erb
@@ -1,0 +1,14 @@
+<%= tag.div(id:, **html_attributes) do %>
+  <%= panel_title %>
+  <%= panel_body %>
+
+  <% if actions&.any? %>
+    <%= tag.div(class: "#{brand}-panel__actions") do %>
+      <%= tag.div(class: "#{brand}-button-group") do %>
+        <% actions.each do |action| %>
+          <%= action %>
+        <% end %>
+      <% end %>
+    <% end %>
+  <% end %>
+<% end %>

--- a/app/components/govuk_component/panel_component.html.erb
+++ b/app/components/govuk_component/panel_component.html.erb
@@ -2,7 +2,7 @@
   <%= panel_title %>
   <%= panel_body %>
 
-  <% if actions&.any? %>
+  <% if show_actions? %>
     <%= tag.div(class: "#{brand}-panel__actions") do %>
       <%= tag.div(class: "#{brand}-button-group") do %>
         <% actions.each do |action| %>

--- a/app/components/govuk_component/panel_component.rb
+++ b/app/components/govuk_component/panel_component.rb
@@ -56,6 +56,14 @@ private
     title.present? || panel_content.present?
   end
 
+  def show_actions?
+    if !interruption && actions?
+      Rails.logger.warn(%(Actions will not be rendered unless the panel is in interruption mode))
+    end
+
+    interruption && actions?
+  end
+
   class Action < GovukComponent::Base
     include GovukLinkHelper
     include GovukVisuallyHiddenHelper

--- a/app/components/govuk_component/panel_component.rb
+++ b/app/components/govuk_component/panel_component.rb
@@ -1,27 +1,29 @@
 class GovukComponent::PanelComponent < GovukComponent::Base
-  attr_reader :id, :title_text, :text, :heading_level
+  attr_reader :id, :title_text, :text, :heading_level, :interruption
 
   renders_one :title_html
+  renders_many :actions, "Action"
 
-  def initialize(title_text: nil, text: nil, heading_level: 1, id: nil, classes: [], html_attributes: {})
+  def initialize(title_text: nil, text: nil, interruption: false, heading_level: 1, id: nil, classes: [], html_attributes: {})
     @heading_level = heading_level
     @title_text    = title_text
     @text          = text
     @id            = id
+    @interruption  = interruption
 
     super(classes:, html_attributes:)
-  end
-
-  def call
-    tag.div(id:, **html_attributes) do
-      safe_join([panel_title, panel_body].compact)
-    end
   end
 
 private
 
   def default_attributes
-    { class: "#{brand}-panel #{brand}-panel--confirmation" }
+    {
+      class: "#{brand}-panel #{brand}-panel--#{mode}",
+    }
+  end
+
+  def mode
+    interruption ? 'interruption' : 'confirmation'
   end
 
   def heading_tag
@@ -52,5 +54,32 @@ private
 
   def render?
     title.present? || panel_content.present?
+  end
+
+  class Action < GovukComponent::Base
+    include GovukLinkHelper
+    include GovukVisuallyHiddenHelper
+
+    attr_reader :text, :href, :type
+
+    def initialize(text:, href:, type: :button, classes: [], html_attributes: {})
+      @text = text
+      @href = href
+      @type = type
+
+      super(classes:, html_attributes:)
+    end
+
+    def default_attributes
+      {}
+    end
+
+    def call
+      case type.to_sym
+      when :button then govuk_button_link_to(text, href, inverse: true, **html_attributes)
+      when :link then govuk_link_to(text, href, inverse: true, **html_attributes)
+      else fail ArgumentError, "unrecognised type (must be :link or :button)"
+      end
+    end
   end
 end

--- a/guide/content/components/panel.slim
+++ b/guide/content/components/panel.slim
@@ -17,4 +17,10 @@ markdown:
   markdown:
     Any content passed in via the block will be rendered beneath the title.
 
+== render('/partials/example.*',
+  caption: "Interruption panels",
+  code: interruption_panel) do
+
+  markdown:
+    Interruption panels can be used to pause the user's journey to give them important information.
 == render('/partials/related-navigation.*', links: panel_info)

--- a/guide/lib/examples/exit_this_page_helpers.rb
+++ b/guide/lib/examples/exit_this_page_helpers.rb
@@ -1,5 +1,5 @@
 module Examples
-  module BreadcrumbsHelpers
+  module ExitThisPageHelpers
     def exit_this_page_normal
       <<~EXIT_THIS_PAGE
         = govuk_exit_this_page

--- a/guide/lib/examples/panel_helpers.rb
+++ b/guide/lib/examples/panel_helpers.rb
@@ -18,5 +18,18 @@ module Examples
           strong ABC123
       PANEL
     end
+
+    def interruption_panel
+      <<~PANEL
+        = govuk_panel(title_text: "Is your height correct?", interruption: true) do |panel|
+          p.govuk-body
+            | You entered your height as
+            strong< 9m
+            | .
+
+          - panel.with_action(text: "Yes, this is correct", href: "#")
+          - panel.with_action(text: "No, change my height", href: "#", type: :link)
+      PANEL
+    end
   end
 end

--- a/guide/lib/helpers.rb
+++ b/guide/lib/helpers.rb
@@ -105,6 +105,7 @@ use_helper Examples::BreadcrumbsHelpers
 use_helper Examples::BackLinkHelpers
 use_helper Examples::CookieBannerHelpers
 use_helper Examples::DetailsHelpers
+use_helper Examples::ExitThisPageHelpers
 use_helper Examples::FooterHelpers
 use_helper Examples::GenericHeaderHelpers
 use_helper Examples::HeaderHelpers

--- a/guide/lib/helpers/formatters.rb
+++ b/guide/lib/helpers/formatters.rb
@@ -65,17 +65,7 @@ module Helpers
   private
 
     def beautify(html)
-      # All tags except textarea appear to line up correctly when
-      # newlines are placed after tags and before closing tags,
-      # except textarea which we need to account for manually 😒
-      HtmlBeautifier
-        .beautify(
-          html
-            .gsub(">", ">\n")
-            .gsub("\<\/", "\n\<\/")
-            .gsub(/>\s+<\/textarea>/, "></textarea>")
-            .strip
-        )
+      HtmlBeautifier.beautify(html)
     end
   end
 end

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
 
   let(:title_text) { 'Springfield' }
   let(:text) { 'A noble spirit embiggens the smallest man' }
-  let(:kwargs) { { title_text:, text: } }
+  let(:interruption_mode) { false }
+  let(:kwargs) { { title_text:, text:, interruption: interruption_mode } }
 
   it_behaves_like 'a component that accepts custom classes'
   it_behaves_like 'a component that accepts custom HTML attributes'
@@ -96,6 +97,64 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
 
     specify 'nothing is rendered' do
       expect(rendered_content).to be_blank
+    end
+  end
+
+  context 'when in interruption: true' do
+    let(:interruption_mode) { true }
+
+    specify 'renders interruption panel' do
+      render_inline(described_class.new(**kwargs))
+
+      expect(rendered_content).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--interruption) })
+    end
+
+    context 'when actions are present' do
+      describe 'buttons' do
+        specify 'actions are inverse buttons by default and rendered in a actions div within the panel' do
+          render_inline(described_class.new(**kwargs)) do |component|
+            component.with_action(text: "Yes", href: "#")
+          end
+
+          expect(rendered_content).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--interruption) }) do
+            with_tag('div', with: { class: 'govuk-panel__actions' }) do
+              with_tag('a', text: 'Yes', with: { href: '#', class: %w(govuk-button govuk-button--inverse) })
+            end
+          end
+        end
+      end
+
+      describe 'links' do
+        specify 'links are inverse links rendered in a actions div within the panel' do
+          render_inline(described_class.new(**kwargs)) do |component|
+            component.with_action(text: "No", href: "#", type: :link)
+          end
+
+          expect(rendered_content).to have_tag('div', with: { class: %w(govuk-panel govuk-panel--interruption) }) do
+            with_tag('div', with: { class: 'govuk-panel__actions' }) do
+              with_tag('a', text: 'No', with: { href: '#', class: %w(govuk-link govuk-link--inverse) })
+            end
+          end
+        end
+
+        specify 'passing the type in as a string works too' do
+          render_inline(described_class.new(**kwargs)) do |component|
+            component.with_action(text: "No", href: "#", type: 'link')
+          end
+
+          expect(rendered_content).to have_tag('a', text: 'No', with: { href: '#', class: %w(govuk-link govuk-link--inverse) })
+        end
+      end
+
+      describe 'invalid types' do
+        specify 'links are inverse links rendered in a actions div within the panel' do
+          expect {
+            render_inline(described_class.new(**kwargs)) do |component|
+              component.with_action(text: "No", href: "#", type: :other)
+            end
+          }.to raise_error(ArgumentError, 'unrecognised type (must be :link or :button)')
+        end
+      end
     end
   end
 end

--- a/spec/components/govuk_component/panel_component_spec.rb
+++ b/spec/components/govuk_component/panel_component_spec.rb
@@ -155,6 +155,26 @@ RSpec.describe(GovukComponent::PanelComponent, type: :component) do
           }.to raise_error(ArgumentError, 'unrecognised type (must be :link or :button)')
         end
       end
+
+      context 'when not in interruption mode' do
+        let(:interruption_mode) { false }
+
+        before do
+          allow(Rails.logger).to receive(:warn).and_call_original
+
+          render_inline(described_class.new(**kwargs)) do |component|
+            component.with_action(text: "Yes", href: "#")
+          end
+        end
+
+        specify 'no actions are rendered' do
+          expect(rendered_content).not_to have_tag('div', with: { class: 'govuk-panel__actions' })
+        end
+
+        specify 'a warning is logged' do
+          expect(Rails.logger).to have_received(:warn).with(%(Actions will not be rendered unless the panel is in interruption mode))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Version 6.4.0 of the GOV.UK design system added [interruption panels](https://design-system.service.gov.uk/patterns/interruption-pages/) which are used to interrupt users' journeys to prompt them to check important information.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/c7427836-dac6-4ce4-8f0e-c029aa2396eb" />


- **Add interruption mode to panel component**
- **Fix module name for `ExitThisPageHelpers` examples**
- **Simplify HTML beautification**
