### PR TITLE
Rename footer attributes for consistency with headers

### DIFF
--- a/app/components/govuk_component/footer_component.html.erb
+++ b/app/components/govuk_component/footer_component.html.erb
@@ -1,4 +1,4 @@
-<%= tag.footer(**footer_attributes) do %>
+<%= tag.footer(**footer_html_attributes) do %>
   <%= content %>
   <%= tag.div(**html_attributes) do %>
     <%= tag.div(**container_html_attributes) do %>

--- a/app/components/govuk_component/footer_component.rb
+++ b/app/components/govuk_component/footer_component.rb
@@ -10,7 +10,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
   renders_one :content_after_meta_items
   renders_one :meta_licence_html
 
-  attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright_text, :copyright_url, :custom_container_classes, :footer_attributes
+  attr_reader :meta_items, :meta_text, :meta_items_title, :meta_licence, :copyright_text, :copyright_url, :custom_container_classes, :footer_html_attributes
 
   def initialize(
     classes: [],
@@ -18,7 +18,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     container_html_attributes: {},
     copyright_text: config.default_footer_copyright_text,
     copyright_url: config.default_footer_copyright_url,
-    footer_attributes: {},
+    footer_html_attributes: {},
     html_attributes: {},
     meta_items: {},
     meta_items_title: "Support links",
@@ -37,7 +37,7 @@ class GovukComponent::FooterComponent < GovukComponent::Base
     @copyright_url                    = copyright_url
     @custom_container_classes         = container_classes
     @custom_container_html_attributes = container_html_attributes
-    @footer_attributes                = footer_attributes
+    @footer_html_attributes           = footer_html_attributes
 
     super(classes:, html_attributes:)
   end

--- a/spec/components/govuk_component/footer_component_spec.rb
+++ b/spec/components/govuk_component/footer_component_spec.rb
@@ -368,15 +368,15 @@ RSpec.describe(GovukComponent::FooterComponent, type: :component) do
   end
 
   describe "adding custom attributes to the footer element" do
-    let(:footer_attributes) { { lang: 'es', class: 'purple' } }
-    let(:kwargs) { { footer_attributes: } }
+    let(:footer_html_attributes) { { lang: 'es', class: 'purple' } }
+    let(:kwargs) { { footer_html_attributes: } }
 
     subject! do
       render_inline(GovukComponent::FooterComponent.new(**kwargs))
     end
 
     it "renders the footer wth custom attributes" do
-      expect(rendered_content).to have_tag('footer', with: footer_attributes)
+      expect(rendered_content).to have_tag('footer', with: footer_html_attributes)
     end
   end
 end


### PR DESCRIPTION
## Summary

Rename `footer_attributes` to `footer_html_attributes` on the footer component to be consistent with the header components.

> [!IMPORTANT]
> This is a **breaking API change**, but there are currently no known usages of `footer_attributes`.